### PR TITLE
Use a UUID for the filename to avoid name collisions across multiple CI jobs

### DIFF
--- a/lib/rspec/buildkite/insights/uploader.rb
+++ b/lib/rspec/buildkite/insights/uploader.rb
@@ -8,6 +8,8 @@ require_relative "tracer"
 require "active_support"
 require "active_support/notifications"
 
+require "securerandom"
+
 module RSpec::Buildkite::Insights
   class Uploader
     class Trace
@@ -68,7 +70,7 @@ module RSpec::Buildkite::Insights
         end
 
         config.after(:suite) do
-          filename = "tmp/bk-insights-#{$$}.json.gz"
+          filename = "tmp/bk-insights-#{SecureRandom.uuid}.json.gz"
           data_set = { results: uploader.traces.map(&:as_json) }
 
           File.open(filename, "wb") do |f|


### PR DESCRIPTION
Since it currently uses the process ID for the random file name, it makes it hard to batch download all the output files. If I download them all to a folder, they basically all end up writing over each other because they have this name:

<img width="319" alt="image" src="https://user-images.githubusercontent.com/25882/109281331-24cf8600-7857-11eb-92e9-7285c6750e9c.png">

This file output is temporary anyway (maybe we'd like to keep it?) so this change should be fine.