### PR TITLE
Use AS::Notifications.monotonic_subscribe

### DIFF
--- a/lib/rspec/buildkite/insights/uploader.rb
+++ b/lib/rspec/buildkite/insights/uploader.rb
@@ -249,7 +249,7 @@ module RSpec::Buildkite::Insights
         end
       end
 
-      ActiveSupport::Notifications.subscribe("sql.active_record") do |name, start, finish, id, payload|
+      ActiveSupport::Notifications.monotonic_subscribe("sql.active_record") do |name, start, finish, id, payload|
         tracer&.backfill(:sql, finish - start, { query: payload[:sql] })
       end
     end


### PR DESCRIPTION
I found `subscribe` has a monotonic version of it, should we use it for a more accurate duration?

Introduced in https://github.com/rails/rails/pull/36184.