### PR TITLE
Should not fail when there is no tracer

### DIFF
--- a/lib/rspec/buildkite/insights/network.rb
+++ b/lib/rspec/buildkite/insights/network.rb
@@ -17,7 +17,7 @@ module RSpec::Buildkite::Insights
 
     module VCRPatch
       def handle
-        if request_type == :stubbed_by_vcr && tracer = RSpec::Buildkite::Insights::Uploader&.tracer
+        if request_type == :stubbed_by_vcr && tracer = RSpec::Buildkite::Insights::Uploader.tracer
           tracer.current_span.detail.merge!(stubbed: "vcr")
         end
 
@@ -42,7 +42,7 @@ module RSpec::Buildkite::Insights
       def response_for_request(request_signature)
         response_from_webmock = super
 
-        if response_from_webmock && tracer = RSpec::Buildkite::Insights::Uploader&.tracer
+        if response_from_webmock && tracer = RSpec::Buildkite::Insights::Uploader.tracer
           tracer.current_span.detail.merge!(stubbed: "webmock")
         end
 


### PR DESCRIPTION
When request processed in different thread, `tracer` is `nil` here, we should continue working if no span to set at all.

Because even after rspec-buildkite-insights is loaded/configured, some code might run outside of any rspec test