### PR TITLE
Handle when socket disconnected already

### DIFF
--- a/lib/rspec/buildkite/insights/socket_connection.rb
+++ b/lib/rspec/buildkite/insights/socket_connection.rb
@@ -23,6 +23,7 @@ module RSpec::Buildkite::Insights
   end
 
   class SocketConnection
+    extend Forwardable
     def_delegators :@conn_detail, :url, :uri, :headers, :port
 
     def initialize(session, url, headers)


### PR DESCRIPTION
https://3.basecamp.com/3453178/buckets/20365997/messages/3637018731

This PR extracts methods and add a `current_socket` method that will set up a new socket if somehow we got disconnected somewhere.

- [ ] confirm this PR still works with buildkite/buildkite