### PR TITLE
Dont block people workflow when @socket is nil

### DIFF
--- a/lib/rspec/buildkite/insights/socket_connection.rb
+++ b/lib/rspec/buildkite/insights/socket_connection.rb
@@ -70,9 +70,11 @@ module RSpec::Buildkite::Insights
     end
 
     def transmit(data, type: :text)
+      return if @socket.nil?
+
       raw_data = data.to_json
       frame = WebSocket::Frame::Outgoing::Client.new(data: raw_data, type: :text, version: @version)
-      @socket&.write(frame.to_s)
+      @socket.write(frame.to_s)
     rescue Errno::EPIPE
       @session.disconnected(self)
       disconnect


### PR DESCRIPTION
`@socket` could be disconnected in different thread maybe?

This is a quick way to avoid errors out in people’s builds. Involved one in #13.