### PR TITLE
Automatically add our reporter to formatters

### DIFF
--- a/lib/rspec/buildkite/insights/uploader.rb
+++ b/lib/rspec/buildkite/insights/uploader.rb
@@ -88,6 +88,8 @@ module RSpec::Buildkite::Insights
       RSpec::Buildkite::Insights.uploader = self
 
       RSpec.configure do |config|
+        config.add_formatter RSpec::Buildkite::Insights::Reporter
+
         config.before(:suite) do
           if RSpec::Buildkite::Insights.api_token
             contact_uri = URI.parse(RSpec::Buildkite::Insights.url)


### PR DESCRIPTION
Turns out we can add our reporter to users’s formatters 😍

https://www.rubydoc.info/github/rspec/rspec-core/RSpec%2FCore%2FConfiguration:add_formatter

Then user can have one less configuration in order to use insights gem.