### PR TITLE
Add our reporter after other formatters added

### DIFF
--- a/lib/rspec/buildkite/insights/uploader.rb
+++ b/lib/rspec/buildkite/insights/uploader.rb
@@ -88,9 +88,9 @@ module RSpec::Buildkite::Insights
       RSpec::Buildkite::Insights.uploader = self
 
       RSpec.configure do |config|
-        config.add_formatter RSpec::Buildkite::Insights::Reporter
-
         config.before(:suite) do
+          config.add_formatter RSpec::Buildkite::Insights::Reporter
+
           if RSpec::Buildkite::Insights.api_token
             contact_uri = URI.parse(RSpec::Buildkite::Insights.url)
 


### PR DESCRIPTION
Paired with @matthewd.

@matthewd and I had this originally inside the `before(:suite)` block:

```ruby
config.before(:suite) do
  if config.formatters.empty?
    config.add_formatter config.default_formatter
  end
  config.add_formatter RSpec::Buildkite::Insights::Reporter
end
```

but actually I found that in `before(:suite)`, there are always `config.formatters`, so it is not necessary to add the `default_formatter` (those 3 `if` lines).

The problem of adding our reporter before the `before(:suite)` is that it is too early. The `RSpec.config.formatters` will be:

```ruby
[RSpec::Buildkite::Insights::Reporter, RSpec::Core::Formatters::DeprecationFormatter, RSpec::Core::Formatters::FallbackMessageFormatter]
```

and `RSpec` does not do the magic of adding a `doc` formatter because it sees we already got a `RSpec::Buildkite::Insights::Reporter` and think it can report output.

While adding our reporter **inside** the `before(:suite)`. The `RSpec.config.formatters` will be:

```ruby
[RSpec::Core::Formatters::DocumentationFormatter, RSpec::Core::Formatters::DeprecationFormatter, RSpec::Buildkite::Insights::Reporter]
```

Because the `spec_helper.rb` from people’s app already done, `config.formatters` that is capable of reporting output should already exist. Adding our reporter then put us in the formatters array to report results, but the `documentation` formatter (or other user-sepecified formatter) will handle the output to Terminal for us 😉