### PR TITLE
Ruby 3 need to explictly use double splat

### DIFF
--- a/lib/rspec/buildkite/insights/network.rb
+++ b/lib/rspec/buildkite/insights/network.rb
@@ -7,7 +7,7 @@ module RSpec::Buildkite::Insights
         detail = { method: request.method.upcase, url: request.uri.to_s, lib: "net-http" }
 
         http_tracer = RSpec::Buildkite::Insights::Uploader.tracer
-        http_tracer&.enter("http", detail)
+        http_tracer&.enter("http", **detail)
 
         super
       ensure
@@ -30,7 +30,7 @@ module RSpec::Buildkite::Insights
         detail = { method: request.verb.to_s.upcase, url: request.uri.to_s, lib: "http" }
 
         http_tracer = RSpec::Buildkite::Insights::Uploader.tracer
-        http_tracer&.enter("http", detail)
+        http_tracer&.enter("http", **detail)
 
         super
       ensure

--- a/lib/rspec/buildkite/insights/uploader.rb
+++ b/lib/rspec/buildkite/insights/uploader.rb
@@ -151,7 +151,7 @@ module RSpec::Buildkite::Insights
       RSpec::Buildkite::Insights::Network.configure
 
       ActiveSupport::Notifications.subscribe("sql.active_record") do |name, start, finish, id, payload|
-        tracer&.backfill(:sql, finish - start, { query: payload[:sql] })
+        tracer&.backfill(:sql, finish - start, **{ query: payload[:sql] })
       end
     end
 


### PR DESCRIPTION
I upgraded my personal project that uses Insights gem to Ruby 3.0 and found we need these argument changes to make it Ruby 3 compatible 😅

The error Ruby 3 complained was:

<img width="1084" alt="CleanShot 2021-05-11 at 10 05 00@2x" src="https://user-images.githubusercontent.com/1000669/117742762-5f36a580-b240-11eb-81be-7cd5f31a571d.png">
