### PR TITLE
Instrument sleep method

### DIFF
--- a/lib/rspec/buildkite/insights/object.rb
+++ b/lib/rspec/buildkite/insights/object.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module RSpec::Buildkite::Insights
+  class Object
+    module CustomObjectSleep
+      def sleep(duration)
+        tracer = RSpec::Buildkite::Insights::Uploader.tracer
+        tracer&.enter("sleep")
+
+        super
+      ensure
+        tracer&.leave
+      end
+    end
+
+    def self.configure
+      ::Object.prepend(CustomObjectSleep)
+    end
+  end
+end

--- a/lib/rspec/buildkite/insights/uploader.rb
+++ b/lib/rspec/buildkite/insights/uploader.rb
@@ -8,6 +8,7 @@ require "websocket"
 
 require_relative "tracer"
 require_relative "network"
+require_relative "object"
 require_relative "session"
 require_relative "reporter"
 require_relative "ci"
@@ -149,6 +150,7 @@ module RSpec::Buildkite::Insights
       end
 
       RSpec::Buildkite::Insights::Network.configure
+      RSpec::Buildkite::Insights::Object.configure
 
       ActiveSupport::Notifications.subscribe("sql.active_record") do |name, start, finish, id, payload|
         tracer&.backfill(:sql, finish - start, **{ query: payload[:sql] })


### PR DESCRIPTION
so we know how much time people’s test suite spent in `sleep` ([Capybara codebase uses a lot of `sleep`](https://github.com/teamcapybara/capybara/search?q=sleep) while waiting for elements to appear).
