### PR TITLE
Fix URI is NULL for HTTP requests

### DIFF
--- a/lib/rspec/buildkite/insights/network.rb
+++ b/lib/rspec/buildkite/insights/network.rb
@@ -5,7 +5,7 @@ module RSpec::Buildkite::Insights
     module NetHTTPPatch
       def request(request, *args, &block)
         unless uri = request.uri
-          protocol = @use_ssl ? "https" : "http"
+          protocol = use_ssl? ? "https" : "http"
           uri = URI.join("#{protocol}://#{address}:#{port}", request.path)
         end
 


### PR DESCRIPTION
This is 1st step that fixes empty URIs, but the URI we are getting are not the ones customers are interested/wanted/expected. We are getting URIs from Capybara talking to (Selenium) Web Drivers that look like `127.0.0.1/__identify__`, `127.0.0.1/session`, not a user testing URIs like `/admin/this/page`...

- [x] Patch webdrivers so we can report interesting URIs — moved to #22.