### PR TITLE
Suppress tracking for irrelevant Capybara, Selenium internal HTTP requests

### DIFF
--- a/lib/rspec/buildkite/insights/tracer.rb
+++ b/lib/rspec/buildkite/insights/tracer.rb
@@ -41,6 +41,11 @@ module RSpec::Buildkite::Insights
       @stack.pop
     end
 
+    def disable
+      new_entry = Span.new("disable", Concurrent.monotonic_time, nil, {})
+      @stack << new_entry
+    end
+
     def backfill(section, duration, **detail)
       new_entry = Span.new(section, Concurrent.monotonic_time - duration, Concurrent.monotonic_time, detail)
       current_span.children << new_entry


### PR DESCRIPTION
@matthewd This is where we left from last time with the idea of disable and hook into webdriver. I haven’t made any progress yet.