### PR TITLE
Introduce 30s Timeout to blocking operations

### DIFF
--- a/lib/rspec/buildkite/insights.rb
+++ b/lib/rspec/buildkite/insights.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
+require "timeout"
+
 require_relative "insights/version"
 
 module RSpec::Buildkite::Insights
   class Error < StandardError; end
+  class TimeoutError < ::Timeout::Error; end
 
   DEFAULT_URL = "https://insights-api.buildkite.com/v1/uploads"
 


### PR DESCRIPTION
## Summary

This PR introduced timeout by [Ruby’s Timeout](https://rubyapi.org/3.0/o/timeout) with a default of 30s. Timeout applies to two blocking operations we currently have, these blocking operations are where the Collector could possibly hang.

## How to test this

- Have buildkite/buildkite started and reference your local insights gem on this branch.
- Open actioncable gem (via `bundle info actioncable`). 
- Add  `sleep 0.1` to [`ActionCable::Connection::Base#send_welcome_message`](https://github.com/rails/rails/blob/2ddcaa1a6fdf9e14d144f6dc6a734eae6712a8fa/actioncable/lib/action_cable/connection/base.rb#L195).
- Restart buildkite/buildkite if it is already running to pick up the changes we just made to actioncable gem
- Change your [local insights gem’s timeout](https://github.com/buildkite/rspec-buildkite-insights/blob/c3a708eea1a611a3006f4b2d742e568f4ea6f197/lib/rspec/buildkite/insights.rb#L26) to `0.00001`
- When you run a spec locally against local buildkite, you will see:

```

Randomized with seed 43441
RSpec Buildkite Insights timed out. Please get in touch with support@buildkite.com with the following information: "{\"channel\":\"Insights::UploadChannel\",\"id\":\"20c6bc0c-d5fb-432a-89d7-bc37ba205ed6\"}"
RSpec Buildkite Insights timed out. Please get in touch with support@buildkite.com with the following information: "{\"channel\":\"Insights::UploadChannel\",\"id\":\"20c6bc0c-d5fb-432a-89d7-bc37ba205ed6\"}"
.

Finished in 0.35933 seconds (files took 2.85 seconds to load)
1 example, 0 failures

Randomized with seed 43441
```

timeout messages print and tests continue to run.
