### PR TITLE
Don't join in disconnect if thread is current thread

### DIFF
--- a/lib/rspec/buildkite/insights/socket_connection.rb
+++ b/lib/rspec/buildkite/insights/socket_connection.rb
@@ -94,7 +94,7 @@ module RSpec::Buildkite::Insights
 
     def disconnect
       @socket.close
-      @thread&.join
+      @thread&.join unless @thread == Thread.current
       @socket = nil
     end
   end


### PR DESCRIPTION
A thread error from PR #28 I thought I could punt into the next PR could not be punted until the next PR 😅 It's causing this [failing build](https://buildkite.com/buildkite/buildkite/builds/36866) on the PR that [bumps the gem](https://github.com/buildkite/buildkite/pull/6771) on buildkite/buildkite. 

<img width="1170" alt="CleanShot 2021-07-26 at 09 43 23@2x" src="https://user-images.githubusercontent.com/1000669/126919119-c1adff07-ca17-41a7-989b-365cc8add9d5.png">
