### PR TITLE
Catch ssl write error, and get it to trigger reconnection flow

### DIFF
--- a/lib/rspec/buildkite/insights/socket_connection.rb
+++ b/lib/rspec/buildkite/insights/socket_connection.rb
@@ -92,7 +92,7 @@ module RSpec::Buildkite::Insights
       raw_data = data.to_json
       frame = WebSocket::Frame::Outgoing::Client.new(data: raw_data, type: :text, version: @version)
       @socket.write(frame.to_s)
-    rescue Errno::EPIPE
+    rescue Errno::EPIPE, OpenSSL::SSL::SSLError => e
       return unless @socket
       @session.disconnected(self)
       disconnect

--- a/spec/insights/socket_connection_spec.rb
+++ b/spec/insights/socket_connection_spec.rb
@@ -5,6 +5,47 @@ require "rspec/buildkite/insights/session"
 require "rspec/buildkite/insights/socket_connection"
 
 RSpec.describe "RSpec::Buildkite::Insights::SocketConnection" do
-  xit "send the headers with https protocol for wss websocket"
-  xit "send the headers with http protocol for ws websocket"
+  let(:session_double) { instance_double("RSpec::Buildkite::Insights::Session") }
+  let(:socket_connection) { RSpec::Buildkite::Insights::SocketConnection.new(session_double, "fake_url", {}) }
+  let(:ssl_socket_double) { instance_double("OpenSSL::SSL::SSLSocket") }
+  let(:tcp_socket_double) { instance_double("TCPSocket") }
+  let(:handshake_double) { instance_double("WebSocket::Handshake::Client") }
+  let(:frame_double) { instance_double("WebSocket::Frame::Outgoing::Client") }
+
+  before do
+    allow(TCPSocket).to receive(:new).and_return(tcp_socket_double)
+
+    allow(URI).to receive(:parse).and_return(OpenStruct.new(scheme: "wss", host: 3000, port: 443))
+
+    allow(OpenSSL::SSL::SSLSocket).to receive(:new).and_return(ssl_socket_double)
+    allow(ssl_socket_double).to receive(:connect)
+    allow(ssl_socket_double).to receive(:readpartial)
+    allow(ssl_socket_double).to receive(:close)
+
+    allow(WebSocket::Handshake::Client).to receive(:new).and_return(handshake_double)
+    allow(handshake_double).to receive(:finished?).and_return(true)
+    allow(handshake_double).to receive(:valid?).and_return(true)
+    allow(handshake_double).to receive(:version).and_return("12")
+
+    allow(WebSocket::Frame::Outgoing::Client).to receive(:new).and_return(frame_double)
+    allow(frame_double).to receive(:to_s).and_return("hi")
+  end
+
+  describe "#transmit" do
+    it "calls disconnected if it gets an SSL error" do
+      write_call_count = 0
+      allow(ssl_socket_double).to receive(:write) {
+        write_call_count += 1
+        # the first write is part of the handshaking process, so let it succeed
+        if write_call_count == 1
+          nil
+        else
+          raise OpenSSL::SSL::SSLError
+        end
+      }
+
+      expect(session_double).to  receive(:disconnected)
+      socket_connection.transmit("hi")
+    end
+  end
 end


### PR DESCRIPTION
@sj26 came across this error in [this job](https://buildkite.com/buildkite/buildkite/builds/37267#3f29e9f2-60a1-4de0-bd1f-4946b27d0f08). Insights team did some investigating and it appears that since we added stricter SSL connection parameters in https://github.com/buildkite/rspec-buildkite-insights/commit/557c2585c9e263ee5eb94887e54df9c1ffd473fc we're now seeing a new `OpenSSL::SSL::SSLError` error when we try to write to a broken socket. This PR catches that error and triggers the reconnection flow. Also added a test for this. 