### PR TITLE
Return a random UUID if not running Collector on Buildkite

### DIFF
--- a/lib/rspec/buildkite/insights/ci.rb
+++ b/lib/rspec/buildkite/insights/ci.rb
@@ -4,14 +4,21 @@ require "securerandom"
 
 module RSpec::Buildkite::Insights::CI
   def self.env
-    {
-      "CI" => "buildkite",
-      "key" => ENV["BUILDKITE_BUILD_ID"] || SecureRandom.uuid,
-      "url" => ENV["BUILDKITE_BUILD_URL"],
-      "branch" => ENV["BUILDKITE_BRANCH"],
-      "commit_sha" => ENV["BUILDKITE_COMMIT"],
-      "number" => ENV["BUILDKITE_BUILD_NUMBER"],
-      "job_id" => ENV["BUILDKITE_JOB_ID"]
-    }
+    if ENV["BUILDKITE"]
+      {
+        "CI" => "buildkite",
+        "key" => ENV["BUILDKITE_BUILD_ID"],
+        "url" => ENV["BUILDKITE_BUILD_URL"],
+        "branch" => ENV["BUILDKITE_BRANCH"],
+        "commit_sha" => ENV["BUILDKITE_COMMIT"],
+        "number" => ENV["BUILDKITE_BUILD_NUMBER"],
+        "job_id" => ENV["BUILDKITE_JOB_ID"]
+      }
+    else
+      {
+        "CI" => nil,
+        "key" => SecureRandom.uuid
+      }
+    end
   end
 end

--- a/spec/insights/ci_spec.rb
+++ b/spec/insights/ci_spec.rb
@@ -21,13 +21,8 @@ RSpec.describe "RSpec::Buildkite::Insights::CI" do
       result = RSpec::Buildkite::Insights::CI.env
 
       expect(result).to match({
-        "CI" => "buildkite",
-        "key" => "845ac829-2ab3-4bbb-9e24-3529755a6d37",
-        "url" => nil,
-        "branch" => nil,
-        "commit_sha" => nil,
-        "number" => nil,
-        "job_id" => nil
+        "CI" => nil,
+        "key" => "845ac829-2ab3-4bbb-9e24-3529755a6d37"
       })
     end
 


### PR DESCRIPTION
This PR brings back `NoCI` support from #35.

In #35, I removed CI detection support and also the `NoCI` class and we need it to run collector locally (lack of Run key), this PR adds back the `key` when we are not actually running on Buildkite (that is, run Collector locally).