### PR TITLE
Set keep alive timeout to 15s

### DIFF
--- a/lib/rspec/buildkite/insights/uploader.rb
+++ b/lib/rspec/buildkite/insights/uploader.rb
@@ -100,7 +100,7 @@ module RSpec::Buildkite::Insights
             contact_uri = URI.parse(RSpec::Buildkite::Insights.url)
 
             http = Net::HTTP.new(contact_uri.host, contact_uri.port)
-            http.keep_alive_timeout = 30
+            http.keep_alive_timeout = 15
             http.use_ssl = contact_uri.scheme == "https"
 
             authorization_header = "Token token=\"#{RSpec::Buildkite::Insights.api_token}\""


### PR DESCRIPTION
Indeed Ruby set to `2s`

```
[6] pry(main)> http = Net::HTTP.new(uri.host, uri.port)
=> #<Net::HTTP google.com:443 open=false>
[7] pry(main)> http.keep_alive_timeout
=> 2
```

Per https://github.com/stripe/stripe-ruby/commit/650114abcaa9871ff03a466b54cb9aba05bce9f2, it seems better to have a higher value.

[MDN example](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive) sets to 5s:

> timeout: An integer representing the time in seconds that the host will allow an idle connection to remain open before it is closed. A connection is idle if no data is sent or received by a host. A host may keep an idle connection open for longer than timeout seconds, but the host should attempt to retain a connection for at least timeout seconds.

Set to 15s in conjunction with #39 introduced’s open timeout 15s.

