### PR TITLE
Rename insights to analytics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in rspec-buildkite-insights.gemspec
+# Specify your gem's dependencies in rspec-buildkite-analytics.gemspec
 gemspec
 
 gem "rake", "~> 13.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-buildkite-insights (0.2.0)
+    rspec-buildkite-analytics (0.2.0)
       activesupport
       rspec-core
       rspec-expectations
@@ -46,7 +46,7 @@ PLATFORMS
 DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.0)
-  rspec-buildkite-insights!
+  rspec-buildkite-analytics!
 
 BUNDLED WITH
    2.2.20

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RSpec Buildkite Insights
+# RSpec Buildkite Analytics
 
 This gem collects data about your test suite's performance and reliability, and allows you to see trends and insights about your test suite over time ✨
 
@@ -9,13 +9,13 @@ Add the gem to your Gemfile:
 ```ruby
 group :test do
   # ...
-  gem "rspec-buildkite-insights"
+  gem "rspec-buildkite-analytics"
 end
 ```
 
 Configure your API key:
 ```ruby
-RSpec::Buildkite::Insights.configure do |config|
+RSpec::Buildkite::Analytics.configure do |config|
   config.suite_key = "........"
   # other config
 end
@@ -28,7 +28,7 @@ $ bundle
 
 Lastly, commit and push your changes to start analysing your tests:
 ```
-$ git commit -m "Add Buildkite Test Insights client"
+$ git commit -m "Add Buildkite Test Analytics client"
 $ git push
 ```
 

--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "rspec/buildkite/insights"
+require "rspec/buildkite/analytics"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/rspec/buildkite/analytics.rb
+++ b/lib/rspec/buildkite/analytics.rb
@@ -2,13 +2,13 @@
 
 require "timeout"
 
-require_relative "insights/version"
+require_relative "analytics/version"
 
-module RSpec::Buildkite::Insights
+module RSpec::Buildkite::Analytics
   class Error < StandardError; end
   class TimeoutError < ::Timeout::Error; end
 
-  DEFAULT_URL = "https://insights-api.buildkite.com/v1/uploads"
+  DEFAULT_URL = "https://analytics-api.buildkite.com/v1/uploads"
 
   class << self
     attr_accessor :api_token
@@ -19,11 +19,11 @@ module RSpec::Buildkite::Insights
   end
 
   def self.configure(token: nil, url: nil, filename: nil)
-    self.api_token = token || ENV["BUILDKITE_INSIGHTS_TOKEN"]
+    self.api_token = token || ENV["BUILDKITE_ANALYTICS_TOKEN"]
     self.url = url || DEFAULT_URL
     self.filename = filename
 
-    require_relative "insights/uploader"
+    require_relative "analytics/uploader"
 
     self::Uploader.configure
   end

--- a/lib/rspec/buildkite/analytics/ci.rb
+++ b/lib/rspec/buildkite/analytics/ci.rb
@@ -2,7 +2,7 @@
 
 require "securerandom"
 
-module RSpec::Buildkite::Insights::CI
+module RSpec::Buildkite::Analytics::CI
   def self.env
     if ENV["BUILDKITE"]
       {

--- a/lib/rspec/buildkite/analytics/network.rb
+++ b/lib/rspec/buildkite/analytics/network.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module RSpec::Buildkite::Insights
+module RSpec::Buildkite::Analytics
   class Network
     module NetHTTPPatch
       def request(request, *args, &block)
@@ -11,7 +11,7 @@ module RSpec::Buildkite::Insights
 
         detail = { method: request.method.upcase, url: uri.to_s, lib: "net-http" }
 
-        http_tracer = RSpec::Buildkite::Insights::Uploader.tracer
+        http_tracer = RSpec::Buildkite::Analytics::Uploader.tracer
         http_tracer&.enter("http", **detail)
 
         super
@@ -22,7 +22,7 @@ module RSpec::Buildkite::Insights
 
     module VCRPatch
       def handle
-        if request_type == :stubbed_by_vcr && tracer = RSpec::Buildkite::Insights::Uploader.tracer
+        if request_type == :stubbed_by_vcr && tracer = RSpec::Buildkite::Analytics::Uploader.tracer
           tracer.current_span.detail.merge!(stubbed: "vcr")
         end
 
@@ -34,7 +34,7 @@ module RSpec::Buildkite::Insights
       def perform(request, options)
         detail = { method: request.verb.to_s.upcase, url: request.uri.to_s, lib: "http" }
 
-        http_tracer = RSpec::Buildkite::Insights::Uploader.tracer
+        http_tracer = RSpec::Buildkite::Analytics::Uploader.tracer
         http_tracer&.enter("http", **detail)
 
         super
@@ -47,7 +47,7 @@ module RSpec::Buildkite::Insights
       def response_for_request(request_signature)
         response_from_webmock = super
 
-        if response_from_webmock && tracer = RSpec::Buildkite::Insights::Uploader.tracer
+        if response_from_webmock && tracer = RSpec::Buildkite::Analytics::Uploader.tracer
           tracer.current_span.detail.merge!(stubbed: "webmock")
         end
 

--- a/lib/rspec/buildkite/analytics/object.rb
+++ b/lib/rspec/buildkite/analytics/object.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-module RSpec::Buildkite::Insights
+module RSpec::Buildkite::Analytics
   class Object
     module CustomObjectSleep
       def sleep(duration)
-        tracer = RSpec::Buildkite::Insights::Uploader.tracer
+        tracer = RSpec::Buildkite::Analytics::Uploader.tracer
         tracer&.enter("sleep")
 
         super

--- a/lib/rspec/buildkite/analytics/reporter.rb
+++ b/lib/rspec/buildkite/analytics/reporter.rb
@@ -1,4 +1,4 @@
-module RSpec::Buildkite::Insights
+module RSpec::Buildkite::Analytics
   class Reporter
     RSpec::Core::Formatters.register self, :example_passed, :example_failed, :example_pending
 
@@ -8,13 +8,13 @@ module RSpec::Buildkite::Insights
 
     def handle_example(notification)
       example = notification.example
-      trace = RSpec::Buildkite::Insights.uploader.traces.find do |trace|
+      trace = RSpec::Buildkite::Analytics.uploader.traces.find do |trace|
         example.id == trace.example.id
       end
 
       if trace
         trace.example = example
-        RSpec::Buildkite::Insights.session&.write_result(trace)
+        RSpec::Buildkite::Analytics.session&.write_result(trace)
       end
     end
 

--- a/lib/rspec/buildkite/analytics/session.rb
+++ b/lib/rspec/buildkite/analytics/session.rb
@@ -2,7 +2,7 @@
 
 require_relative "socket_connection"
 
-module RSpec::Buildkite::Insights
+module RSpec::Buildkite::Analytics
   class Session
     # Picked 75 as the magic timeout number as it's longer than the TCP timeout of 60s 🤷‍♀️
     CONFIRMATION_TIMEOUT = 75
@@ -26,7 +26,7 @@ module RSpec::Buildkite::Insights
 
       connect
     rescue TimeoutError => e
-      $stderr.puts "rspec-buildkite-insights could not establish an initial connection with Buildkite. Please contact support."
+      $stderr.puts "rspec-buildkite-analytics could not establish an initial connection with Buildkite. Please contact support."
     end
 
     def disconnected(connection)
@@ -48,7 +48,7 @@ module RSpec::Buildkite::Insights
           connect
         rescue SocketConnection::HandshakeError, RejectedSubscription, TimeoutError, SocketConnection::SocketError => e
           if reconnection_count > MAX_RECONNECTION_ATTEMPTS
-            $stderr.puts "rspec-buildkite-insights experienced a disconnection and could not reconnect to Buildkite due to #{e.message}. Please contact support."
+            $stderr.puts "rspec-buildkite-analytics experienced a disconnection and could not reconnect to Buildkite due to #{e.message}. Please contact support."
             raise e
           else
             sleep(WAIT_BETWEEN_RECONNECTIONS)
@@ -139,7 +139,7 @@ module RSpec::Buildkite::Insights
     end
 
     def pop_with_timeout
-      Timeout.timeout(30, RSpec::Buildkite::Insights::TimeoutError, "Waited 30 seconds") do
+      Timeout.timeout(30, RSpec::Buildkite::Analytics::TimeoutError, "Waited 30 seconds") do
         @queue.pop
       end
     end

--- a/lib/rspec/buildkite/analytics/socket_connection.rb
+++ b/lib/rspec/buildkite/analytics/socket_connection.rb
@@ -4,7 +4,7 @@ require "socket"
 require "openssl"
 require "json"
 
-module RSpec::Buildkite::Insights
+module RSpec::Buildkite::Analytics
   class SocketConnection
     class HandshakeError < StandardError; end
     class SocketError < StandardError; end

--- a/lib/rspec/buildkite/analytics/tracer.rb
+++ b/lib/rspec/buildkite/analytics/tracer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module RSpec::Buildkite::Insights
+module RSpec::Buildkite::Analytics
   class Tracer
     class Span
       attr_accessor :section, :start_at, :end_at, :detail, :children

--- a/lib/rspec/buildkite/analytics/version.rb
+++ b/lib/rspec/buildkite/analytics/version.rb
@@ -2,7 +2,7 @@
 
 module RSpec
   module Buildkite
-    module Insights
+    module Analytics
       VERSION = "0.2.0"
     end
   end

--- a/rspec-buildkite-insights.gemspec
+++ b/rspec-buildkite-insights.gemspec
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
-require_relative "lib/rspec/buildkite/insights/version"
+require_relative "lib/rspec/buildkite/analytics/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "rspec-buildkite-insights"
-  spec.version       = RSpec::Buildkite::Insights::VERSION
+  spec.name          = "rspec-buildkite-analytics"
+  spec.version       = RSpec::Buildkite::Analytics::VERSION
   spec.authors       = ["Buildkite"]
   spec.email         = ["hello@buildkite.com"]
 
-  spec.summary       = "Track execution of specs and report to Buildkite Insights"
+  spec.summary       = "Track execution of specs and report to Buildkite Analytics"
   spec.homepage      = "https://buildkite.com"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
   spec.metadata["allowed_push_host"] = "http://example.com"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/buildkite/rspec-buildkite-insights"
+  spec.metadata["source_code_uri"] = "https://github.com/buildkite/rspec-buildkite-analytics"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/spec/analytics/ci_spec.rb
+++ b/spec/analytics/ci_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "rspec/buildkite/insights/ci"
+require "rspec/buildkite/analytics/ci"
 
-RSpec.describe "RSpec::Buildkite::Insights::CI" do
+RSpec.describe "RSpec::Buildkite::Analytics::CI" do
   describe ".env" do
     let(:build_uuid) { "b8959ui2-l0dk-4829-i029-97999t1e09d6" }
     let(:build_url) { "https://buildkite.com/buildkite/buildkite/builds/1234" }
@@ -18,7 +18,7 @@ RSpec.describe "RSpec::Buildkite::Insights::CI" do
     it "not running on Buildkite" do
       fake_env("BUILDKITE", nil)
       allow(SecureRandom).to receive(:uuid) { "845ac829-2ab3-4bbb-9e24-3529755a6d37" }
-      result = RSpec::Buildkite::Insights::CI.env
+      result = RSpec::Buildkite::Analytics::CI.env
 
       expect(result).to match({
         "CI" => nil,
@@ -35,7 +35,7 @@ RSpec.describe "RSpec::Buildkite::Insights::CI" do
       fake_env("BUILDKITE_BUILD_NUMBER", number)
       fake_env("BUILDKITE_JOB_ID", job_id)
 
-      result = RSpec::Buildkite::Insights::CI.env
+      result = RSpec::Buildkite::Analytics::CI.env
 
       expect(result).to match({
         "CI" => "buildkite",

--- a/spec/analytics/socket_connection_spec.rb
+++ b/spec/analytics/socket_connection_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 require "websocket"
-require "rspec/buildkite/insights/session"
-require "rspec/buildkite/insights/socket_connection"
+require "rspec/buildkite/analytics/session"
+require "rspec/buildkite/analytics/socket_connection"
 
-RSpec.describe "RSpec::Buildkite::Insights::SocketConnection" do
-  let(:session_double) { instance_double("RSpec::Buildkite::Insights::Session") }
-  let(:socket_connection) { RSpec::Buildkite::Insights::SocketConnection.new(session_double, "fake_url", {}) }
+RSpec.describe "RSpec::Buildkite::Analytics::SocketConnection" do
+  let(:session_double) { instance_double("RSpec::Buildkite::Analytics::Session") }
+  let(:socket_connection) { RSpec::Buildkite::Analytics::SocketConnection.new(session_double, "fake_url", {}) }
   let(:ssl_socket_double) { instance_double("OpenSSL::SSL::SSLSocket") }
   let(:tcp_socket_double) { instance_double("TCPSocket") }
   let(:handshake_double) { instance_double("WebSocket::Handshake::Client") }

--- a/spec/insights_spec.rb
+++ b/spec/insights_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-RSpec.describe RSpec::Buildkite::Insights do
+RSpec.describe RSpec::Buildkite::Analytics do
   it "can configure api_token, url, and filename" do
-    insights = RSpec::Buildkite::Insights
-    ENV["BUILDKITE_INSIGHTS_TOKEN"] = "MyToken"
+    analytics = RSpec::Buildkite::Analytics
+    ENV["BUILDKITE_ANALYTICS_TOKEN"] = "MyToken"
 
-    insights.configure
+    analytics.configure
 
-    expect(insights.api_token).to eq "MyToken"
-    expect(insights.url).to eq "https://insights-api.buildkite.com/v1/uploads"
-    expect(insights.filename).to be nil
+    expect(analytics.api_token).to eq "MyToken"
+    expect(analytics.url).to eq "https://analytics-api.buildkite.com/v1/uploads"
+    expect(analytics.filename).to be nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "rspec/buildkite/insights"
+require "rspec/buildkite/analytics"
 
 Dir["spec/support/**/*.rb"].each { |f| require File.expand_path(f) }
 


### PR DESCRIPTION
This PR changes the namespace from `insights` to `analytics`. I have tested that this works by bundling locally with the changes in [buildkite/buildkite PR #6946](https://github.com/buildkite/buildkite/pull/6946), and running `BUILDKITE_ANALYTICS_TOKEN=local rspec spec/models/cluster`. 

<img width="1726" alt="Screen Shot 2021-08-23 at 4 51 25 PM" src="https://user-images.githubusercontent.com/4241125/130393742-250f561c-2ad1-4ceb-9162-55ec01eb22b7.png">

So I think from here my plan is:
1. Rename this repository to `rspec-buildkite-analytics`
2. Publish to Ruby Gems 
3. Add new env variables of `BUILDKITE_ANALYTICS_TOKEN` and `BUILDKITE_ANALYTICS_URL`
4. Finish up [buildkite/buildkite PR #6946](https://github.com/buildkite/buildkite/pull/6946) by bundling with Ruby Gems version of rspec-buildkite-analytics
5. Deploy and everything magically works???? 
6. Remove env variables of `BUILDKITE_INSIGHTS_TOKEN` and `BUILDKITE_INSIGHTS_URL`