### PR TITLE
Capture Commit Message to display on UI

### DIFF
--- a/lib/rspec/buildkite/analytics/ci.rb
+++ b/lib/rspec/buildkite/analytics/ci.rb
@@ -12,7 +12,8 @@ module RSpec::Buildkite::Analytics::CI
         "branch" => ENV["BUILDKITE_BRANCH"],
         "commit_sha" => ENV["BUILDKITE_COMMIT"],
         "number" => ENV["BUILDKITE_BUILD_NUMBER"],
-        "job_id" => ENV["BUILDKITE_JOB_ID"]
+        "job_id" => ENV["BUILDKITE_JOB_ID"],
+        "message" => ENV["BUILDKITE_MESSAGE"]
       }
     else
       {

--- a/spec/analytics/ci_spec.rb
+++ b/spec/analytics/ci_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
     let(:commit_sha) { "3683a9a92ec0f3055849cd5488e8e9347c6e2878" }
     let(:number) { "4242" }
     let(:job_id) { "j3459ui2-l0dk-4829-i029-97999t1e09d6" }
+    let(:message) { "Merge pull request #1 from buildkite/branch\n commit title" }
 
     before do
       allow(ENV).to receive(:[]).and_call_original
@@ -34,6 +35,7 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
       fake_env("BUILDKITE_COMMIT", commit_sha)
       fake_env("BUILDKITE_BUILD_NUMBER", number)
       fake_env("BUILDKITE_JOB_ID", job_id)
+      fake_env("BUILDKITE_MESSAGE", message)
 
       result = RSpec::Buildkite::Analytics::CI.env
 
@@ -44,7 +46,8 @@ RSpec.describe "RSpec::Buildkite::Analytics::CI" do
         "branch" => branch,
         "commit_sha" => commit_sha,
         "number" => number,
-        "job_id" => job_id
+        "job_id" => job_id,
+        "message" => message
       })
     end
   end


### PR DESCRIPTION
Typical commit message for a merged Pull Request on GitHub looks like this

```
Merge pull request #6949 from buildkite/update-bitbucket-webhooks-url

Update bitbucket webhooks admin URL
```

we need to capture this for UI like this:

<img width="736" alt="CleanShot 2021-08-24 at 13 52 05@2x" src="https://user-images.githubusercontent.com/1000669/130557750-f4c714b9-d8fa-488a-8d98-674357cd0abb.png">
