### PR TITLE
expose output in formatter for duplicate formatter check

### DIFF
--- a/lib/rspec/buildkite/analytics/reporter.rb
+++ b/lib/rspec/buildkite/analytics/reporter.rb
@@ -2,6 +2,8 @@ module RSpec::Buildkite::Analytics
   class Reporter
     RSpec::Core::Formatters.register self, :example_passed, :example_failed, :example_pending
 
+    attr_reader :output
+
     def initialize(output)
       @output = output
     end


### PR DESCRIPTION
A few customers using Knapsack Pro in Queue mode are hitting this error, because Knapsack Pro loads rspec multiple times
![CleanShot 2021-10-26 at 12 05 57](https://user-images.githubusercontent.com/4241125/139161769-3b53068a-77b7-4acc-a954-6519ac0cad84.jpeg)
Which is failing due to the [check here](https://github.com/rspec/rspec-core/blob/main/lib/rspec/core/formatters.rb#L197) expecting an output method defined on our custom formatter

I think if we just expose this via an attr_reader it should be all peachy 
