### PR TITLE
Detailed tracing can be disabled

### DIFF
--- a/lib/buildkite/test_collector/library_hooks/minitest.rb
+++ b/lib/buildkite/test_collector/library_hooks/minitest.rb
@@ -11,11 +11,6 @@ class MiniTest::Test
   include Buildkite::TestCollector::MinitestPlugin
 end
 
-Buildkite::TestCollector::Network.configure
-Buildkite::TestCollector::Object.configure
-
-ActiveSupport::Notifications.subscribe("sql.active_record") do |name, start, finish, id, payload|
-  Buildkite::TestCollector::Uploader.tracer&.backfill(:sql, finish - start, **{ query: payload[:sql] })
-end
+Buildkite::TestCollector.enable_tracing!
 
 Buildkite::TestCollector::Uploader.configure

--- a/lib/buildkite/test_collector/library_hooks/rspec.rb
+++ b/lib/buildkite/test_collector/library_hooks/rspec.rb
@@ -32,9 +32,4 @@ RSpec.configure do |config|
   end
 end
 
-Buildkite::TestCollector::Network.configure
-Buildkite::TestCollector::Object.configure
-
-ActiveSupport::Notifications.subscribe("sql.active_record") do |name, start, finish, id, payload|
-  Buildkite::TestCollector::Uploader.tracer&.backfill(:sql, finish - start, **{ query: payload[:sql] })
-end
+Buildkite::TestCollector.enable_tracing!


### PR DESCRIPTION
Sometimes people might run into issues where the detailed tracing is incompatible with their tests or is causing tests to run slower. To make it so they can keep using Test Analytics I've added the option to disable the detailed tracing.

```ruby
Buildkite::TestCollector.configure(
  ...
  tracing_enabled: false
)
```