### PR TITLE
Add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @buildkite/test-analytics


### PR DESCRIPTION
This PR adds the Buildkite Test Analytics team as code owner. Future merges to main will require a review from a code owner.