### PR TITLE
Fix `project_dir` issue expecting a string, not a `Pathname`

### DIFF
--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -66,7 +66,7 @@ module Buildkite::TestCollector::MinitestPlugin
 
     def project_dir
       if defined?(Rails) && Rails.respond_to?(:root)
-        Rails.root
+        Rails.root.to_s
       else
         Dir.getwd
       end

--- a/spec/test_collector/minitest_plugin/trace_spec.rb
+++ b/spec/test_collector/minitest_plugin/trace_spec.rb
@@ -37,5 +37,15 @@ RSpec.describe Buildkite::TestCollector::MinitestPlugin::Trace do
 
       expect(history_json).to include('347611.734956')
     end
+
+    it "sets the filename, when not in Rails" do
+      expect(trace.as_hash[:file_name].split("/").last).to eq("method_double.rb")
+    end
+
+    let(:rails) { double("Rails", root: Pathname.new("./")) }
+    it "sets the filename, when in Rails" do
+      Rails = rails
+      expect(trace.as_hash[:file_name].split("/").last).to eq("method_double.rb")
+    end
   end
 end


### PR DESCRIPTION
**Issue**
See #111, this lib seems to expect a string for the `project_dir`, but `Rails.root` returns `Pathname`

**Steps to reproduce**
Run minitest with the gem enabled in a Rails 6+ app

**Expected**
The gem should do its job and report analytics back to Buildkite

**Actual**
See #111 for the output

As suggested by @nickvanw, this PR simply calls `to_s` on `Rails.root` in the `project_dir` method in `minitest_plugin/trace.rb`

I added a test too that fails without the fix.