### PR TITLE
Remove unused debug_filepath

### DIFF
--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -19,15 +19,13 @@ module Buildkite
       attr_accessor :uploader
       attr_accessor :session
       attr_accessor :debug_enabled
-      attr_accessor :debug_filepath
       attr_accessor :tracing_enabled
     end
 
-    def self.configure(hook:, token: nil, url: nil, debug_enabled: false, debug_filepath: nil, tracing_enabled: true)
+    def self.configure(hook:, token: nil, url: nil, debug_enabled: false, tracing_enabled: true)
       self.api_token = token || ENV["BUILDKITE_ANALYTICS_TOKEN"]
       self.url = url || DEFAULT_URL
       self.debug_enabled = debug_enabled || !!(ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"])
-      self.debug_filepath = debug_filepath || ENV["BUILDKITE_ANALYTICS_DEBUG_FILEPATH"] || Dir.tmpdir
       self.tracing_enabled = tracing_enabled
 
       self.hook_into(hook)


### PR DESCRIPTION
Thanks to @pda pointed out in https://github.com/buildkite/test-collector-ruby/pull/97#issuecomment-1147098900.

Remove unused `debug_filepath`.

This was introduced at https://github.com/buildkite/test-collector-ruby/commit/8d99faf74dbf505476202c2ab67e5a0cdd493c76 to dump debug logs into a preferred location but it is not in used anymore

I do not believe anyone but us uses this feature but this is a breaking API change for the `configure` method.