### PR TITLE
Remove warnings 

### DIFF
--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -4,7 +4,8 @@ require "active_support/core_ext/hash/indifferent_access"
 
 module Buildkite::TestCollector::MinitestPlugin
   class Trace
-    attr_accessor :example, :failure_reason, :failure_expanded
+    attr_accessor :example
+    attr_writer :failure_reason, :failure_expanded
     attr_reader :id, :history
 
     RESULT_CODES = {

--- a/lib/buildkite/test_collector/uploader.rb
+++ b/lib/buildkite/test_collector/uploader.rb
@@ -57,7 +57,7 @@ module Buildkite::TestCollector
           end
         else
           request_id = response.to_hash["x-request-id"]
-          Buildkite::TestCollector.logger.info "rspec-buildkite-analytics could not establish an initial connection with Buildkite. You may be missing some data for this test suite, please contact support."
+          Buildkite::TestCollector.logger.info "rspec-buildkite-analytics could not establish an initial connection with Buildkite. You may be missing some data for this test suite, please contact support with request ID #{request_id}."
         end
       else
         if !!ENV["BUILDKITE_BUILD_ID"]


### PR DESCRIPTION
Remove these warnings from the gem for Minitest:

```
/Users/hhh/dev/test-collector-ruby/lib/buildkite/test_collector/minitest_plugin/trace.rb:75: warning: method redefined; discarding old failure_reason
/Users/hhh/dev/test-collector-ruby/lib/buildkite/test_collector/minitest_plugin/trace.rb:79: warning: method redefined; discarding old failure_expanded
```

And remove a warning from `Uploader`:

```
/Users/hhh/dev/test-collector-ruby/lib/buildkite/test_collector/uploader.rb:59: warning: assigned but unused variable - request_id
```