### PR TITLE
Use new Minitest spelling

### DIFF
--- a/lib/buildkite/test_collector/library_hooks/minitest.rb
+++ b/lib/buildkite/test_collector/library_hooks/minitest.rb
@@ -7,7 +7,7 @@ require_relative "../minitest_plugin"
 
 Buildkite::TestCollector.uploader = Buildkite::TestCollector::Uploader
 
-class MiniTest::Test
+class Minitest::Test
   include Buildkite::TestCollector::MinitestPlugin
 end
 


### PR DESCRIPTION
It has been renamed to `Minitest` since 2013 (but `MiniTest` still kept as an alias) but for the love of our pinkies...


[![CleanShot 2022-06-09 at 12 47 34@2x](https://user-images.githubusercontent.com/1000669/172760051-d2bfd6ea-e58a-45f0-a3c7-2d23a0907752.png)](https://github.com/minitest/minitest/blob/master/History.rdoc#500--2013-05-10-)

