### PR TITLE
Releave v0.8.2 of rspec-buildkite-analytics with deprecation messages

### DIFF
--- a/lib/rspec/buildkite/analytics.rb
+++ b/lib/rspec/buildkite/analytics.rb
@@ -26,6 +26,8 @@ module RSpec::Buildkite::Analytics
     self.debug_enabled = debug_enabled || !!(ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"])
     self.debug_filepath = debug_filepath || ENV["BUILDKITE_ANALYTICS_DEBUG_FILEPATH"] || Dir.tmpdir
 
+    Kernel.warn "UNSUPPORTED: The rspec-buildkite-analytics gem has been renamed to buildkite-test_collector. rspec-buildkite-analytics will not receive any further maintenance. Please follow our docs https://buildkite.com/docs/test-analytics/ruby-collectors to upgrade to the new gem: https://rubygems.org/gems/buildkite-test_collector. Thank you!"
+
     require_relative "analytics/uploader"
 
     self::Uploader.configure

--- a/lib/rspec/buildkite/analytics/version.rb
+++ b/lib/rspec/buildkite/analytics/version.rb
@@ -3,7 +3,7 @@
 module RSpec
   module Buildkite
     module Analytics
-      VERSION = "0.8.1"
+      VERSION = "0.8.2"
       NAME = "rspec-buildkite"
     end
   end

--- a/rspec-buildkite-analytics.gemspec
+++ b/rspec-buildkite-analytics.gemspec
@@ -6,11 +6,16 @@ Gem::Specification.new do |spec|
   spec.name          = "rspec-buildkite-analytics"
   spec.version       = RSpec::Buildkite::Analytics::VERSION
   spec.authors       = ["Buildkite"]
-  spec.email         = ["hello@buildkite.com"]
+  spec.email         = ["support+analytics@buildkite.com"]
 
   spec.summary       = "Track execution of specs and report to Buildkite Analytics"
+  spec.description   = "UNSUPPORTED: The rspec-buildkite-analytics gem has been renamed to buildkite-test_collector. rspec-buildkite-analytics will not receive any further maintenance. Please follow our docs https://buildkite.com/docs/test-analytics/ruby-collectors to upgrade to the new gem: https://rubygems.org/gems/buildkite-test_collector. Thank you!"
   spec.homepage      = "https://github.com/buildkite/rspec-buildkite-analytics"
   spec.license       = "MIT"
+
+  spec.post_install_message = <<~MSG
+    UNSUPPORTED: The rspec-buildkite-analytics gem has been renamed to buildkite-test_collector. rspec-buildkite-analytics will not receive any further maintenance. Please follow our docs https://buildkite.com/docs/test-analytics/ruby-collectors to upgrade to the new gem: https://rubygems.org/gems/buildkite-test_collector. Thank you!
+  MSG
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/buildkite/rspec-buildkite-analytics"


### PR DESCRIPTION
This merges to v0.8.1 (7082e50).

This PR adds deprecation notice to the old gem description, post install messages and warning when using it.