### PR TITLE
Implement Test Location Prefix 

### DIFF
--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -58,7 +58,14 @@ module Buildkite::TestCollector::MinitestPlugin
     alias_method :identifier, :location
 
     def file_name
-      @file_name ||= File.join('./', source_location[0].delete_prefix(project_dir))
+      @file_name ||= begin
+        prefix = ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"]
+        if prefix && !prefix.empty?
+          File.join(prefix, source_location[0].delete_prefix(project_dir))
+        else
+          File.join('./', source_location[0].delete_prefix(project_dir))
+        end
+      end
     end
 
     def line_number

--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -39,6 +39,7 @@ module Buildkite::TestCollector::MinitestPlugin
         scope: example.class.name,
         name: example.name,
         identifier: identifier,
+        location_prefix: location_prefix,
         location: location,
         file_name: file_name,
         result: result,
@@ -50,6 +51,15 @@ module Buildkite::TestCollector::MinitestPlugin
 
     private
 
+    def location_prefix
+      return @location_prefix if defined? @location_prefix
+
+      prefix = ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"]
+      if prefix && !prefix.empty?
+        @location_prefix = prefix
+      end
+    end
+
     def location
       if file_name
         "#{file_name}:#{line_number}"
@@ -59,9 +69,8 @@ module Buildkite::TestCollector::MinitestPlugin
 
     def file_name
       @file_name ||= begin
-        prefix = ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"]
-        if prefix && !prefix.empty?
-          File.join(prefix, source_location[0].delete_prefix(project_dir))
+        if location_prefix
+          File.join(location_prefix, source_location[0].delete_prefix(project_dir))
         else
           File.join('./', source_location[0].delete_prefix(project_dir))
         end

--- a/lib/buildkite/test_collector/rspec_plugin/trace.rb
+++ b/lib/buildkite/test_collector/rspec_plugin/trace.rb
@@ -31,7 +31,7 @@ module Buildkite::TestCollector::RSpecPlugin
         scope: example.example_group.metadata[:full_description],
         name: example.description,
         identifier: example.id,
-        location: example.location,
+        location: example_location,
         file_name: file_name,
         result: result,
         failure_reason: failure_reason,
@@ -41,6 +41,17 @@ module Buildkite::TestCollector::RSpecPlugin
     end
 
     private
+
+    def example_location
+      location = example.location
+      prefix = ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"]
+
+      if prefix && !prefix.empty?
+        File.join(prefix, location)
+      else
+        location
+      end
+    end
 
     def file_name
       @file_name ||= begin

--- a/lib/buildkite/test_collector/rspec_plugin/trace.rb
+++ b/lib/buildkite/test_collector/rspec_plugin/trace.rb
@@ -31,6 +31,7 @@ module Buildkite::TestCollector::RSpecPlugin
         scope: example.example_group.metadata[:full_description],
         name: example.description,
         identifier: example.id,
+        location_prefix: location_prefix,
         location: example_location,
         file_name: file_name,
         result: result,
@@ -42,12 +43,20 @@ module Buildkite::TestCollector::RSpecPlugin
 
     private
 
+    def location_prefix
+      return @location_prefix if defined? @location_prefix
+
+      prefix = ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"]
+      if prefix && !prefix.empty?
+        @location_prefix = prefix
+      end
+    end
+
     def example_location
       location = example.location
-      prefix = ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"]
 
-      if prefix && !prefix.empty?
-        File.join(prefix, location)
+      if location_prefix
+        File.join(location_prefix, location)
       else
         location
       end

--- a/spec/test_collector/minitest_plugin/trace_spec.rb
+++ b/spec/test_collector/minitest_plugin/trace_spec.rb
@@ -23,8 +23,10 @@ RSpec.describe Buildkite::TestCollector::MinitestPlugin::Trace do
     end
 
     it "returns location from test" do
+      prefix = trace.as_hash[:location_prefix]
       result = trace.as_hash[:location]
 
+      expect(prefix).to be_nil
       expect(result).to eq "./Users/hello/path/to/your_test.rb:42"
     end
 
@@ -32,8 +34,10 @@ RSpec.describe Buildkite::TestCollector::MinitestPlugin::Trace do
       env = ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"]
       ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"] = "payments"
 
+      prefix = trace.as_hash[:location_prefix]
       result = trace.as_hash[:location]
 
+      expect(prefix).to eq "payments"
       expect(result).to eq "payments/Users/hello/path/to/your_test.rb:42"
 
       ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"] = env

--- a/spec/test_collector/minitest_plugin/trace_spec.rb
+++ b/spec/test_collector/minitest_plugin/trace_spec.rb
@@ -17,6 +17,29 @@ RSpec.describe Buildkite::TestCollector::MinitestPlugin::Trace do
     }
   end
 
+  context "Location from Trace" do
+    before do
+      allow(trace).to receive(:source_location) { ["/Users/hello/path/to/your_test.rb", 42] }
+    end
+
+    it "returns location from test" do
+      result = trace.as_hash[:location]
+
+      expect(result).to eq "./Users/hello/path/to/your_test.rb:42"
+    end
+
+    it "adds custom location prefix via ENV" do
+      env = ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"]
+      ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"] = "payments"
+
+      result = trace.as_hash[:location]
+
+      expect(result).to eq "payments/Users/hello/path/to/your_test.rb:42"
+
+      ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"] = env
+    end
+  end
+
   describe '#as_hash' do
     it 'removes invalid UTF-8 characters from top level values' do
       failure_reason = trace.as_hash[:failure_reason]

--- a/spec/test_collector/rspec_plugin/trace_spec.rb
+++ b/spec/test_collector/rspec_plugin/trace_spec.rb
@@ -16,6 +16,29 @@ RSpec.describe Buildkite::TestCollector::RSpecPlugin::Trace do
     }
   end
 
+  context "Location from Trace" do
+    before do
+      allow(example).to receive(:location) { "/Users/hello/path/to/your_test.rb" }
+    end
+
+    it "returns location from test" do
+      result = trace.as_hash[:location]
+
+      expect(result).to eq "/Users/hello/path/to/your_test.rb"
+    end
+
+    it "adds custom location prefix via ENV" do
+      env = ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"]
+      ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"] = "payments"
+
+      result = trace.as_hash[:location]
+
+      expect(result).to eq "payments/Users/hello/path/to/your_test.rb"
+
+      ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"] = env
+    end
+  end
+
   describe '#as_hash' do
     it 'removes invalid UTF-8 characters from top level values' do
       identifier = trace.as_hash[:identifier]

--- a/spec/test_collector/rspec_plugin/trace_spec.rb
+++ b/spec/test_collector/rspec_plugin/trace_spec.rb
@@ -22,8 +22,10 @@ RSpec.describe Buildkite::TestCollector::RSpecPlugin::Trace do
     end
 
     it "returns location from test" do
+      prefix = trace.as_hash[:location_prefix]
       result = trace.as_hash[:location]
 
+      expect(prefix).to be_nil
       expect(result).to eq "/Users/hello/path/to/your_test.rb"
     end
 
@@ -31,8 +33,10 @@ RSpec.describe Buildkite::TestCollector::RSpecPlugin::Trace do
       env = ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"]
       ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"] = "payments"
 
+      prefix = trace.as_hash[:location_prefix]
       result = trace.as_hash[:location]
 
+      expect(prefix).to eq "payments"
       expect(result).to eq "payments/Users/hello/path/to/your_test.rb"
 
       ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"] = env


### PR DESCRIPTION
This Pull Request ports JavaScript Collector feature https://github.com/buildkite/test-collector-javascript/pull/30.

This allows a Monolith repository to configure different test name prefix via environment variable `BUILDKITE_ANALYTICS_LOCATION_PREFIX` across multiple pipelines.