### PR TITLE
Loading minitest without initializing the plugin should work

### DIFF
--- a/lib/minitest/buildkite_collector_plugin.rb
+++ b/lib/minitest/buildkite_collector_plugin.rb
@@ -1,6 +1,6 @@
 module Minitest
   def self.plugin_buildkite_collector_init(options)
-    if Buildkite::TestCollector.respond_to?(:uploader)
+    if defined?(Buildkite::TestCollector::MinitestPlugin) && Buildkite::TestCollector.respond_to?(:uploader)
       self.reporter << Buildkite::TestCollector::MinitestPlugin::Reporter.new(options[:io], options)
     end
   end

--- a/spec/test_collector/minitest_plugin/without_plugin_spec.rb
+++ b/spec/test_collector/minitest_plugin/without_plugin_spec.rb
@@ -1,0 +1,9 @@
+require "minitest"
+
+RSpec.describe "don’t break minitest when the plugin isn’t loaded" do
+  describe "running minitest" do
+    it "should not raise an error" do
+      expect { Minitest.run }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
**Issue**
Requiring the gem but not running `Buildkite::TestCollector.configure(hook: :minitest)` causes an exception:

<img width="1038" alt="CleanShot 2022-06-16 at 15 41 59@2x" src="https://user-images.githubusercontent.com/1229/174095619-73d32615-895f-4b60-903f-0208252110c0.png">

**Steps to reproduce**
- In a Rails 7 app
- Add `buildkite-test_collector` to the `Gemfile`
- Do not add ```Buildkite::TestCollector.configure(hook: :minitest)```

**Expected**
Tests should run fine as though the test collector gem wasn't installed

**Actual**
- If `require "buildkite/test_collector"` is present, but `Buildkite::TestCollector.configure(hook: :minitest)` is not, we get `uninitialized constant Buildkite::TestCollector::MinitestPlugin`

- If neither of the above are present, but the gem is in the Gemfile, we get: `uninitialized constant Minitest::Buildkite`

**Fix**
This just adds an additional constant check in the `Minitest` plugin, and also adds a test to attempt to run Minitest and assert that it runs without raising an exception.