### PR TITLE
Fix Minitest crashing without loading minitest lib hook

### DIFF
--- a/lib/minitest/buildkite_collector_plugin.rb
+++ b/lib/minitest/buildkite_collector_plugin.rb
@@ -1,6 +1,6 @@
 module Minitest
   def self.plugin_buildkite_collector_init(options)
-    if Buildkite::TestCollector.respond_to?(:uploader)
+    if Buildkite::TestCollector.respond_to?(:api_token) && Buildkite::TestCollector.api_token
       self.reporter << Buildkite::TestCollector::MinitestPlugin::Reporter.new(options[:io], options)
     end
   end


### PR DESCRIPTION
The library hooks are loaded as part of the configure call.
However, we don't always want to run test analytics and therefore
only call configure on certain pipelines, builds etc.
As Minitest automatically discovers plugins, this will crash with a
NameError.