### PR TITLE
Remove whitespace characters from ANALYTICS_TOKEN to avoid multi-line headers

### DIFF
--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -23,7 +23,7 @@ module Buildkite
     end
 
     def self.configure(hook:, token: nil, url: nil, debug_enabled: false, tracing_enabled: true)
-      self.api_token = token || ENV["BUILDKITE_ANALYTICS_TOKEN"]
+      self.api_token = (token || ENV["BUILDKITE_ANALYTICS_TOKEN"])&.strip
       self.url = url || DEFAULT_URL
       self.debug_enabled = debug_enabled || !!(ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"])
       self.tracing_enabled = tracing_enabled


### PR DESCRIPTION
Resolves https://github.com/buildkite/test-collector-ruby/issues/122

Ruby 2.5 removed support for multiline headers
https://github.com/ruby/ruby/commit/0078e40115fd53e2cafd4e8cfb6ff5fd7f87c3db

There shouldn't be any new line characters, carriage returns or similar
characters in the BUILDKITE_ANALYTICS_TOKEN environment variable. So we
should remove any instances of leading or trailing whitespace characters
from the token to avoid the error raised in Ruby net/http.

Internal reference:
PIE-927
