### PR TITLE
Make ruby collector work better for non-web app

### DIFF
--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -1,16 +1,19 @@
 # frozen_string_literal: true
 
+module Buildkite
+  module TestCollector
+  end
+end
+
 require "timeout"
 require "tmpdir"
 
+require_relative "test_collector/error"
 require_relative "test_collector/version"
 require_relative "test_collector/logger"
 
 module Buildkite
   module TestCollector
-    class Error < StandardError; end
-    class TimeoutError < ::Timeout::Error; end
-
     DEFAULT_URL = "https://analytics-api.buildkite.com/v1/uploads"
 
     class << self

--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -5,12 +5,32 @@ module Buildkite
   end
 end
 
+require "json"
+require "logger"
+require "net/http"
+require "openssl"
+require "time"
 require "timeout"
 require "tmpdir"
+require "securerandom"
+require "socket"
+require "websocket"
 
-require_relative "test_collector/error"
+require "active_support/core_ext/object/blank"
+require "active_support/core_ext/hash/indifferent_access"
+require "active_support/notifications"
+
 require_relative "test_collector/version"
+require_relative "test_collector/error"
 require_relative "test_collector/logger"
+require_relative "test_collector/ci"
+require_relative "test_collector/http_client"
+require_relative "test_collector/uploader"
+require_relative "test_collector/network"
+require_relative "test_collector/object"
+require_relative "test_collector/tracer"
+require_relative "test_collector/socket_connection"
+require_relative "test_collector/session"
 
 module Buildkite
   module TestCollector

--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "securerandom"
-
 class Buildkite::TestCollector::CI
   def self.env
     new.env

--- a/lib/buildkite/test_collector/error.rb
+++ b/lib/buildkite/test_collector/error.rb
@@ -1,0 +1,4 @@
+module Buildkite::TestCollector
+  class Error < StandardError; end
+  class TimeoutError < ::Timeout::Error; end
+end

--- a/lib/buildkite/test_collector/library_hooks/minitest.rb
+++ b/lib/buildkite/test_collector/library_hooks/minitest.rb
@@ -2,7 +2,6 @@
 
 require "minitest"
 
-require_relative "../uploader"
 require_relative "../minitest_plugin"
 
 Buildkite::TestCollector.uploader = Buildkite::TestCollector::Uploader

--- a/lib/buildkite/test_collector/library_hooks/rspec.rb
+++ b/lib/buildkite/test_collector/library_hooks/rspec.rb
@@ -3,7 +3,6 @@
 require "rspec/core"
 require "rspec/expectations"
 
-require_relative "../uploader"
 require_relative "../rspec_plugin/reporter"
 require_relative "../rspec_plugin/trace"
 

--- a/lib/buildkite/test_collector/logger.rb
+++ b/lib/buildkite/test_collector/logger.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "logger"
-require "time"
-
 module Buildkite::TestCollector
   class Logger < ::Logger
     class Formatter < ::Logger::Formatter

--- a/lib/buildkite/test_collector/minitest_plugin.rb
+++ b/lib/buildkite/test_collector/minitest_plugin.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# Minitest finds this file before setup code
+require_relative "tracer"
+
 require_relative "minitest_plugin/reporter"
 require_relative "minitest_plugin/trace"
 

--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/hash/indifferent_access"
-
 module Buildkite::TestCollector::MinitestPlugin
   class Trace
     attr_accessor :example

--- a/lib/buildkite/test_collector/rspec_plugin/reporter.rb
+++ b/lib/buildkite/test_collector/rspec_plugin/reporter.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "time"
-
 module Buildkite::TestCollector::RSpecPlugin
   class Reporter
     RSpec::Core::Formatters.register self, :example_passed, :example_failed, :example_pending, :dump_summary

--- a/lib/buildkite/test_collector/rspec_plugin/trace.rb
+++ b/lib/buildkite/test_collector/rspec_plugin/trace.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/hash/indifferent_access"
-
 module Buildkite::TestCollector::RSpecPlugin
   class Trace
     attr_accessor :example, :failure_reason, :failure_expanded

--- a/lib/buildkite/test_collector/session.rb
+++ b/lib/buildkite/test_collector/session.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "socket_connection"
-
 module Buildkite::TestCollector
   class Session
     # Picked 75 as the magic timeout number as it's longer than the TCP timeout of 60s 🤷‍♀️
@@ -13,11 +11,11 @@ module Buildkite::TestCollector
     class InitialConnectionFailure < StandardError; end
 
     DISCONNECTED_EXCEPTIONS = [
-      SocketConnection::HandshakeError,
+      Buildkite::TestCollector::SocketConnection::HandshakeError,
+      Buildkite::TestCollector::TimeoutError,
+      Buildkite::TestCollector::SocketConnection::SocketError,
       RejectedSubscription,
-      TimeoutError,
       InitialConnectionFailure,
-      SocketConnection::SocketError
     ]
 
     def initialize(url, authorization_header, channel)
@@ -41,7 +39,7 @@ module Buildkite::TestCollector
       begin
         reconnection_count += 1
         connect
-      rescue TimeoutError, InitialConnectionFailure => e
+      rescue Buildkite::TestCollector::TimeoutError, InitialConnectionFailure => e
         Buildkite::TestCollector.logger.warn("buildkite-test_collector could not establish an initial connection with Buildkite due to #{e}. Attempting retry #{reconnection_count} of #{MAX_RECONNECTION_ATTEMPTS}...")
         if reconnection_count > MAX_RECONNECTION_ATTEMPTS
           Buildkite::TestCollector.logger.error "buildkite-test_collector could not establish an initial connection with Buildkite due to #{e.message} after #{MAX_RECONNECTION_ATTEMPTS} attempts. You may be missing some data for this test suite, please contact support if this issue persists."

--- a/lib/buildkite/test_collector/socket_connection.rb
+++ b/lib/buildkite/test_collector/socket_connection.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "socket"
-require "openssl"
-require "json"
-
 module Buildkite::TestCollector
   class SocketConnection
     class HandshakeError < StandardError; end

--- a/lib/buildkite/test_collector/tracer.rb
+++ b/lib/buildkite/test_collector/tracer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/hash/indifferent_access"
-
 module Buildkite::TestCollector
   class Tracer
     # https://github.com/buildkite/test-collector-ruby/issues/131

--- a/lib/buildkite/test_collector/uploader.rb
+++ b/lib/buildkite/test_collector/uploader.rb
@@ -1,20 +1,5 @@
 # frozen_string_literal: true
 
-require "openssl"
-require "websocket"
-
-require_relative "tracer"
-require_relative "network"
-require_relative "object"
-require_relative "session"
-require_relative "ci"
-require_relative "http_client"
-
-require "active_support"
-require "active_support/notifications"
-
-require "securerandom"
-
 module Buildkite::TestCollector
   class Uploader
     def self.traces

--- a/lib/minitest/buildkite_collector_plugin.rb
+++ b/lib/minitest/buildkite_collector_plugin.rb
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
+# Minitest finds this file before setup code
+require_relative "../buildkite/test_collector"
+require_relative "../buildkite/test_collector/minitest_plugin/reporter"
+
 module Minitest
   def self.plugin_buildkite_collector_init(options)
     if defined?(Buildkite::TestCollector::MinitestPlugin) && Buildkite::TestCollector.respond_to?(:uploader)

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "buildkite/test_collector/ci"
-
 RSpec.describe Buildkite::TestCollector::CI do
   describe ".env" do
     let(:ci) { "true" }

--- a/spec/test_collector/logger_spec.rb
+++ b/spec/test_collector/logger_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "logger"
-require "buildkite/test_collector/logger"
-
 RSpec.describe "Logger" do
   describe ".logger" do
     let(:logger) { Buildkite::TestCollector }

--- a/spec/test_collector/minitest_plugin/reporter_spec.rb
+++ b/spec/test_collector/minitest_plugin/reporter_spec.rb
@@ -2,7 +2,6 @@
 
 require "minitest"
 require "buildkite/test_collector/minitest_plugin/reporter"
-require "buildkite/test_collector/uploader"
 
 RSpec.describe Buildkite::TestCollector::MinitestPlugin::Reporter do
   it "test reporter works with a passed minitest result" do

--- a/spec/test_collector/rspec_plugin/reporter_spec.rb
+++ b/spec/test_collector/rspec_plugin/reporter_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "buildkite/test_collector/rspec_plugin/reporter"
-require "buildkite/test_collector/uploader"
 
 RSpec.describe Buildkite::TestCollector::RSpecPlugin::Reporter do
 

--- a/spec/test_collector/session_spec.rb
+++ b/spec/test_collector/session_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "buildkite/test_collector/session"
-require "buildkite/test_collector/socket_connection"
-
 RSpec.describe Buildkite::TestCollector::Session do
   let(:socket_double) { instance_double("Buildkite::TestCollector::SocketConnection") }
   let(:session) { Buildkite::TestCollector::Session.new("fake_url", "fake_auth", "fake_channel") }

--- a/spec/test_collector/socket_connection_spec.rb
+++ b/spec/test_collector/socket_connection_spec.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "websocket"
-require "buildkite/test_collector/session"
-require "buildkite/test_collector/socket_connection"
-
 RSpec.describe Buildkite::TestCollector::SocketConnection do
   let(:session_double) { instance_double("Buildkite::TestCollector::Session") }
   let(:socket_connection) { Buildkite::TestCollector::SocketConnection.new(session_double, "fake_url", {}) }


### PR DESCRIPTION
This Pull Request explicitly doing all `require` in the entry point `test_collector.rb`.

For Minitest plugin (file named with `_plugin` suffix) in non-web app, we cant be sure our Collector is `require`’d before Minitest finds the plugin, so need to `require` tracer.