### PR TITLE
Allow specifying run name prefix and suffix

### DIFF
--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -39,7 +39,9 @@ class Buildkite::TestCollector::CI
       "debug" => ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"],
       "version" => Buildkite::TestCollector::VERSION,
       "collector" => Buildkite::TestCollector::NAME,
-  }.compact
+      "run_name_prefix" => ENV["BUILDKITE_ANALYTICS_RUN_NAME_PREFIX"],
+      "run_name_suffix" => ENV["BUILDKITE_ANALYTICS_RUN_NAME_SUFFIX"],
+    }.compact
   end
 
   def generic

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -255,6 +255,8 @@ RSpec.describe Buildkite::TestCollector::CI do
           fake_env("BUILDKITE_ANALYTICS_NUMBER", number)
           fake_env("BUILDKITE_ANALYTICS_JOB_ID", job_id)
           fake_env("BUILDKITE_ANALYTICS_MESSAGE", message)
+          fake_env("BUILDKITE_ANALYTICS_RUN_NAME_PREFIX", "run_name_prefix")
+          fake_env("BUILDKITE_ANALYTICS_RUN_NAME_SUFFIX", "run_name_suffix")
         end
 
         it "returns the analytics env" do
@@ -271,7 +273,9 @@ RSpec.describe Buildkite::TestCollector::CI do
             "message" => message,
             "debug" => debug,
             "version" => version,
-            "collector" => name
+            "collector" => name,
+            "run_name_prefix" => "run_name_prefix",
+            "run_name_suffix" => "run_name_suffix",
           })
         end
       end


### PR DESCRIPTION
This will be displayed before and after the name of a Run respectively.

- Prefix: `BUILDKITE_ANALYTICS_RUN_NAME_PREFIX`
- Suffix: `BUILDKITE_ANALYTICS_RUN_NAME_SUFFIX`