### PR TITLE
Use the private reference trick to get time instead

### DIFF
--- a/lib/buildkite/test_collector/tracer.rb
+++ b/lib/buildkite/test_collector/tracer.rb
@@ -6,8 +6,11 @@ module Buildkite::TestCollector
   class Tracer
     # https://github.com/buildkite/test-collector-ruby/issues/131
     class MonotonicTime
+      GET_TIME = Process.method(:clock_gettime)
+      private_constant :GET_TIME
+
       def self.call
-        Process.method(:clock_gettime).call Process::CLOCK_MONOTONIC
+        GET_TIME.call Process::CLOCK_MONOTONIC
       end
     end
 


### PR DESCRIPTION
Avoid breaking test suite that stubs `Process.clock_gettime` by replacing calling `Concurrent.monotonic_time` with a custom `MonotonicTime.call`. 

The fix was suggested by @ChrisBR at https://github.com/buildkite/test-collector-ruby/issues/131#issuecomment-1168343196 (thanks!)