### PR TITLE
Use `after_teardown` instead of `before_teardown` in MiniTest

### DIFF
--- a/lib/buildkite/test_collector/minitest_plugin.rb
+++ b/lib/buildkite/test_collector/minitest_plugin.rb
@@ -12,7 +12,7 @@ module Buildkite::TestCollector::MinitestPlugin
     Thread.current[:_buildkite_tracer] = tracer
   end
 
-  def before_teardown
+  def after_teardown
     super
 
     tracer = Thread.current[:_buildkite_tracer]

--- a/lib/buildkite/test_collector/minitest_plugin.rb
+++ b/lib/buildkite/test_collector/minitest_plugin.rb
@@ -13,8 +13,6 @@ module Buildkite::TestCollector::MinitestPlugin
   end
 
   def after_teardown
-    super
-
     tracer = Thread.current[:_buildkite_tracer]
     if !tracer.nil?
       Thread.current[:_buildkite_tracer] = nil
@@ -23,5 +21,7 @@ module Buildkite::TestCollector::MinitestPlugin
       trace = Buildkite::TestCollector::MinitestPlugin::Trace.new(self, history: tracer.history)
       Buildkite::TestCollector.uploader.traces[trace.source_location] = trace
     end
+
+    super
   end
 end


### PR DESCRIPTION
This should fix #131, where I described the problem in details.
