### PR TITLE
Remove branch reference prefix in Github Actions

### DIFF
--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -69,7 +69,7 @@ class Buildkite::TestCollector::CI
       "CI" => "github_actions",
       "key" => "#{ENV["GITHUB_ACTION"]}-#{ENV["GITHUB_RUN_NUMBER"]}-#{ENV["GITHUB_RUN_ATTEMPT"]}",
       "url" => File.join("https://github.com", ENV["GITHUB_REPOSITORY"], "actions/runs", ENV["GITHUB_RUN_ID"]),
-      "branch" => ENV["GITHUB_REF"],
+      "branch" => ENV["GITHUB_REF_NAME"],
       "commit_sha" => ENV["GITHUB_SHA"],
       "number" => ENV["GITHUB_RUN_NUMBER"],
     }

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Buildkite::TestCollector::CI do
         fake_env("GITHUB_RUN_ATTEMPT", gha_run_attempt)
         fake_env("GITHUB_RUN_ID", gha_run_id)
         fake_env("GITHUB_REPOSITORY", gha_repository)
-        fake_env("GITHUB_REF", gha_ref)
+        fake_env("GITHUB_REF_NAME", gha_ref)
         fake_env("GITHUB_SHA", gha_sha)
       end
 


### PR DESCRIPTION
Resolves https://github.com/buildkite/test-collector-ruby/issues/135

We are using the environment GITHUB_REF which includes the prefix
ref/branch which isn't what we want. GITHUB_REF_NAME returns the
branch/tag without the prefix.

GITHUB_REF returns
* refs/heads/main
* refs/pulls/2000/merge

GITHUB_REF_NAME returns
* main
* my-branch-name

Reference https://docs.github.com/en/actions/learn-github-actions/environment-variables
