### PR TITLE
Revert "Allow specifying run name prefix and suffix"

### DIFF
--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -37,9 +37,7 @@ class Buildkite::TestCollector::CI
       "debug" => ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"],
       "version" => Buildkite::TestCollector::VERSION,
       "collector" => Buildkite::TestCollector::NAME,
-      "run_name_prefix" => ENV["BUILDKITE_ANALYTICS_RUN_NAME_PREFIX"],
-      "run_name_suffix" => ENV["BUILDKITE_ANALYTICS_RUN_NAME_SUFFIX"],
-    }.compact
+  }.compact
   end
 
   def generic

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -253,8 +253,6 @@ RSpec.describe Buildkite::TestCollector::CI do
           fake_env("BUILDKITE_ANALYTICS_NUMBER", number)
           fake_env("BUILDKITE_ANALYTICS_JOB_ID", job_id)
           fake_env("BUILDKITE_ANALYTICS_MESSAGE", message)
-          fake_env("BUILDKITE_ANALYTICS_RUN_NAME_PREFIX", "run_name_prefix")
-          fake_env("BUILDKITE_ANALYTICS_RUN_NAME_SUFFIX", "run_name_suffix")
         end
 
         it "returns the analytics env" do
@@ -271,9 +269,7 @@ RSpec.describe Buildkite::TestCollector::CI do
             "message" => message,
             "debug" => debug,
             "version" => version,
-            "collector" => name,
-            "run_name_prefix" => "run_name_prefix",
-            "run_name_suffix" => "run_name_suffix",
+            "collector" => name
           })
         end
       end


### PR DESCRIPTION
This reverts buildkite/test-collector-ruby#130 which we discussed on Basecamp.