### PR TITLE
Allow specifying execution name prefix / suffix

### DIFF
--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -35,9 +35,11 @@ class Buildkite::TestCollector::CI
       "job_id" => ENV["BUILDKITE_ANALYTICS_JOB_ID"],
       "message" => ENV["BUILDKITE_ANALYTICS_MESSAGE"],
       "debug" => ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"],
+      "execution_name_prefix" => ENV["BUILDKITE_ANALYTICS_EXECUTION_NAME_PREFIX"],
+      "execution_name_suffix" => ENV["BUILDKITE_ANALYTICS_EXECUTION_NAME_SUFFIX"],
       "version" => Buildkite::TestCollector::VERSION,
       "collector" => Buildkite::TestCollector::NAME,
-  }.compact
+    }.compact
   end
 
   def generic

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -73,6 +73,8 @@ RSpec.describe Buildkite::TestCollector::CI do
           fake_env("BUILDKITE_ANALYTICS_NUMBER", number)
           fake_env("BUILDKITE_ANALYTICS_JOB_ID", job_id)
           fake_env("BUILDKITE_ANALYTICS_MESSAGE", message)
+          fake_env("BUILDKITE_ANALYTICS_EXECUTION_NAME_PREFIX", "execution_name_prefix")
+          fake_env("BUILDKITE_ANALYTICS_EXECUTION_NAME_SUFFIX", "execution_name_suffix")
         end
 
         it "returns the analytics env" do
@@ -88,6 +90,8 @@ RSpec.describe Buildkite::TestCollector::CI do
             "job_id" => job_id,
             "message" => message,
             "debug" => debug,
+            "execution_name_prefix" => "execution_name_prefix",
+            "execution_name_suffix" => "execution_name_suffix",
             "version" => version,
             "collector" => name
           })


### PR DESCRIPTION
This will be displayed before and after the name of an Execution respectively

implements PIE-964