### PR TITLE
Suppress errors when connecting to Buildkite

### DIFF
--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -106,6 +106,7 @@ module Buildkite
       block.call
     rescue StandardError => e
       logger.error("Buildkite::TestCollector received exception: #{e}")
+      logger.error("Backtrace:\n#{e.backtrace.join("\n")}")
     end
   end
 end

--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -101,5 +101,11 @@ module Buildkite
         Buildkite::TestCollector::Uploader.tracer&.backfill(:sql, finish - start, **{ query: payload[:sql] })
       end
     end
+
+    def self.safe(&block)
+      block.call
+    rescue StandardError => e
+      logger.error("Buildkite::TestCollector received exception: #{e}")
+    end
   end
 end

--- a/lib/buildkite/test_collector/library_hooks/minitest.rb
+++ b/lib/buildkite/test_collector/library_hooks/minitest.rb
@@ -12,4 +12,4 @@ end
 
 Buildkite::TestCollector.enable_tracing!
 
-Buildkite::TestCollector::Uploader.configure
+Buildkite::TestCollector.safe { Buildkite::TestCollector::Uploader.configure }

--- a/lib/buildkite/test_collector/library_hooks/rspec.rb
+++ b/lib/buildkite/test_collector/library_hooks/rspec.rb
@@ -12,7 +12,7 @@ RSpec.configure do |config|
   config.before(:suite) do
     config.add_formatter Buildkite::TestCollector::RSpecPlugin::Reporter
 
-    Buildkite::TestCollector::Uploader.configure
+    Buildkite::TestCollector.safe { Buildkite::TestCollector::Uploader.configure }
   end
 
   config.around(:each) do |example|

--- a/spec/test_collector_spec.rb
+++ b/spec/test_collector_spec.rb
@@ -24,4 +24,27 @@ RSpec.describe Buildkite::TestCollector do
       expect(analytics.url).to eq "https://analytics-api.buildkite.com/v1/uploads"
     end
   end
+
+  describe ".safe" do
+    let(:logger) { TestLogger.new }
+
+    class TestLogger
+      attr_reader :errors
+
+      def initialize
+        @errors = []
+      end
+
+      def error(message)
+        @errors << message
+      end
+    end
+
+    before { Buildkite::TestCollector.logger = logger }
+
+    it "suppresses exceptions and logs them to logger.error" do
+      expect{ described_class.safe { raise "penguines dance" } }.to_not raise_error
+      expect(logger.errors).to eq(["Buildkite::TestCollector received exception: penguines dance"])
+    end
+  end
 end

--- a/spec/test_collector_spec.rb
+++ b/spec/test_collector_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Buildkite::TestCollector do
 
     it "suppresses exceptions and logs them to logger.error" do
       expect{ described_class.safe { raise "penguines dance" } }.to_not raise_error
-      expect(logger.errors).to eq(["Buildkite::TestCollector received exception: penguines dance"])
+      expect(logger.errors.first).to eq("Buildkite::TestCollector received exception: penguines dance")
     end
   end
 end


### PR DESCRIPTION
It's important the collector does not raise exceptions and cause test
suites to fail. Some customers have seen exceptions raised when
connecting to Buildkite (not a surprise as networks are complicated and
unreliable).

This PR modifies the connection process to catch all StandardErrors and
log them. Trace data will be lost; however, the customer's build will
not fail which is more important.

We also intend to address the underlying issues; however, this PR is an
important defensive measure to protect customer builds.