### PR TITLE
Fix logging level from debug to error

### DIFF
--- a/lib/buildkite/test_collector/socket_connection.rb
+++ b/lib/buildkite/test_collector/socket_connection.rb
@@ -78,7 +78,7 @@ module Buildkite::TestCollector
       rescue EOFError => e
         Buildkite::TestCollector.logger.warn("#{e}")
         if @socket
-          Buildkite::TestCollector.logger.warn("attempting disconnected flow")
+          Buildkite::TestCollector.logger.error("attempting disconnected flow")
           @session.disconnected(self)
           disconnect
         end


### PR DESCRIPTION
PIE-983

When an EOFError exception is raised, we want log at the 'error' level.
This is also consistent with other exceptions that are rescued.

Resolves #141

