### PR TITLE
Release v1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.2.3
+
+- Add ability to specify execution prefix/suffix #140 - @JuanitoFatas
+
 ## v1.1.3
 - Use a private reference to JSON.parse to prevent it being mocked #149 - @ghcan
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,23 @@
 PATH
   remote: .
   specs:
-    buildkite-test_collector (1.1.1)
+    buildkite-test_collector (1.2.3)
       activesupport (>= 5.2, < 8)
       websocket (~> 1.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
+    activesupport (7.0.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     concurrent-ruby (1.1.10)
     diff-lcs (1.4.4)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.16.1)
+    minitest (5.16.3)
     rake (13.0.6)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -32,7 +32,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.3)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     websocket (1.2.9)
 

--- a/lib/buildkite/test_collector/version.rb
+++ b/lib/buildkite/test_collector/version.rb
@@ -2,7 +2,7 @@
 
 module Buildkite
   module TestCollector
-    VERSION = "1.1.3"
+    VERSION = "1.2.3"
     NAME = "buildkite-test_collector"
   end
 end


### PR DESCRIPTION
All changes: https://github.com/buildkite/test-collector-ruby/compare/v1.1.3...2724f0d8196c2f9b0c821184cdf7ec3ca784805c


![CleanShot 2022-08-22 at 16 19 10@2x](https://user-images.githubusercontent.com/1000669/185862250-f10cc28b-91b5-4b1d-a78f-53538f6d2b4d.png)

This PR releases v1.2.3, bump minor version because it introduced a new feature: [Allow specifying execution name prefix / suffix](https://github.com/buildkite/test-collector-ruby/pull/140).




PIE-1028