### PR TITLE
Fix instrumentation of sleep does not support sleeping forever

### DIFF
--- a/lib/buildkite/test_collector/object.rb
+++ b/lib/buildkite/test_collector/object.rb
@@ -7,7 +7,11 @@ module Buildkite::TestCollector
         tracer = Buildkite::TestCollector::Uploader.tracer
         tracer&.enter("sleep")
 
-        super
+        if duration
+          super(duration)
+        else
+          super()
+        end
       ensure
         tracer&.leave
       end

--- a/spec/test_collector/object_spec.rb
+++ b/spec/test_collector/object_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require "timeout"
+
+RSpec.describe Buildkite::TestCollector::CI do
+  it "sleep without duration should not error" do
+    Buildkite::TestCollector::Object.configure
+
+    expect do
+      ::Timeout.timeout(0.5) do
+        sleep
+      end
+    end.to raise_error(Timeout::Error)
+  end
+end


### PR DESCRIPTION
[Kernel#sleep](https://rubyapi.org/3.1/o/kernel#method-i-sleep)

When `sleep` calls without duration `sleep()`, it will sleep forever. We should support this behavior to not break people’s test suite.