### PR TITLE
Release v1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.2.4
+
+- Fix sleep instrumentation errors without argument #153 - @JuanitoFatas
+
 ## v1.2.3
 
 - Add ability to specify execution prefix/suffix #140 - @JuanitoFatas

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    buildkite-test_collector (1.2.3)
+    buildkite-test_collector (1.2.4)
       activesupport (>= 5.2, < 8)
       websocket (~> 1.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3.1)
+    activesupport (7.0.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)

--- a/lib/buildkite/test_collector/version.rb
+++ b/lib/buildkite/test_collector/version.rb
@@ -2,7 +2,7 @@
 
 module Buildkite
   module TestCollector
-    VERSION = "1.2.3"
+    VERSION = "1.2.4"
     NAME = "buildkite-test_collector"
   end
 end


### PR DESCRIPTION
All changes: https://github.com/buildkite/test-collector-ruby/compare/v1.2.3...d41ee84e


This PR releases v1.2.4, bump minor version because it is a bug fix: [Fix instrumentation of sleep does not support sleeping forever #153](https://github.com/buildkite/test-collector-ruby/pull/153).



PIE-1189