### PR TITLE
Allow earlier Rails versions

### DIFF
--- a/buildkite-test_collector.gemspec
+++ b/buildkite-test_collector.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
-  spec.add_dependency "activesupport", ">= 5.2", "< 8"
+  spec.add_dependency "activesupport", ">= 4.2", "< 8"
   spec.add_dependency "websocket", '~> 1.2'
 
   spec.add_development_dependency "rspec-core", '~> 3.10'

--- a/buildkite-test_collector.gemspec
+++ b/buildkite-test_collector.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
-  spec.add_dependency "activesupport", ">= 4.2", "< 8"
+  spec.add_dependency "activesupport", ">= 4.2"
   spec.add_dependency "websocket", '~> 1.2'
 
   spec.add_development_dependency "rspec-core", '~> 3.10'


### PR DESCRIPTION
Changes the minimum supported ActiveSupport version to allow the gem to be used with Rails 4.2 applications. This can be helpful for those using RailsLTS to receive backported security fixes to older versions of Rails.