### PR TITLE
Release v1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.2.5
+
+- Relax activesupport dependency to >= 4.2.0 #155 - @noodl
+
 ## v1.2.4
 
 - Fix sleep instrumentation errors without argument #153 - @JuanitoFatas

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    buildkite-test_collector (1.2.4)
-      activesupport (>= 5.2, < 8)
+    buildkite-test_collector (1.2.5)
+      activesupport (>= 4.2)
       websocket (~> 1.2)
 
 GEM

--- a/lib/buildkite/test_collector/version.rb
+++ b/lib/buildkite/test_collector/version.rb
@@ -2,7 +2,7 @@
 
 module Buildkite
   module TestCollector
-    VERSION = "1.2.4"
+    VERSION = "1.2.5"
     NAME = "buildkite-test_collector"
   end
 end


### PR DESCRIPTION
All changes: https://github.com/buildkite/test-collector-ruby/compare/v1.2.4...64566d59


This PR releases v1.2.5: [allow collector to use in earlier rails version #155](https://github.com/buildkite/test-collector-ruby/pull/155).

