### PR TITLE
Only warn on EOF errors and also catch SSLErrors

### DIFF
--- a/lib/buildkite/test_collector/socket_connection.rb
+++ b/lib/buildkite/test_collector/socket_connection.rb
@@ -75,10 +75,10 @@ module Buildkite::TestCollector
       # These get re-raise from session, we should fail gracefully
       rescue *Buildkite::TestCollector::Session::DISCONNECTED_EXCEPTIONS => e
         Buildkite::TestCollector.logger.error("We could not establish a connection with Buildkite Test Analytics. The error was: #{e.message}. If this is a problem, please contact support.")
-      rescue EOFError => e
+      rescue EOFError, OpenSSL::SSL::SSLError => e
         Buildkite::TestCollector.logger.warn("#{e}")
         if @socket
-          Buildkite::TestCollector.logger.error("attempting disconnected flow")
+          Buildkite::TestCollector.logger.warn("attempting disconnected flow")
           @session.disconnected(self)
           disconnect
         end


### PR DESCRIPTION
[kivikakk](https://github.com/kivikakk) pointed on that they have been observing lots of `EOF` errors and that logging with a 'warn' is more appropriate than 'error'. https://github.com/buildkite/test-collector-ruby/pull/147#issuecomment-1250485611

Their team has currently forked this Collector as a workaround and it would be great if they don't have to maintain their own fork.

`OpenSSL::SSL::SSLError` is raised when using OpenSSL 3 so catching this and handling it the same way as EOF errors are hadnled seems appropriate.

`OpenSSL::SSL::SSLError` is quite a broad exception class (and Ruby's OpenSSL implementation only exposes the error [through the message](https://github.com/ruby/openssl/blob/173be6690589120976bd3f8e55eea13eae6aed46/ext/openssl/ossl.c#L268-L310), so the best we could do is something like:

```
rescue OpenSSL::SSL::SSLError => e
  if e.message == 'SSL_read: unexpected eof while reading'
    # …
  else
    raise
  end
end
``` 