### PR TITLE
Handle ETIMEDOUT during socket connection

### DIFF
--- a/lib/buildkite/test_collector/socket_connection.rb
+++ b/lib/buildkite/test_collector/socket_connection.rb
@@ -82,7 +82,7 @@ module Buildkite::TestCollector
           @session.disconnected(self)
           disconnect
         end
-      rescue Errno::ECONNRESET => e
+      rescue Errno::ECONNRESET, Errno::ETIMEDOUT => e
         Buildkite::TestCollector.logger.error("#{e}")
         if @socket
           Buildkite::TestCollector.logger.error("attempting disconnected flow")


### PR DESCRIPTION
This fixes #161 in which we failed to rescue `Errno::ETIMEDOUT` errors from our socket connection during test runs. This would cause the test run to complete with a non-zero exit code and cause build jobs to fail.

This is the error that is now rescued:
```
bundler: failed to load command: rspec (.../ruby/2.7.0/bin/rspec)
Traceback (most recent call last):
	2: from .../ruby/2.7.0/gems/buildkite-test_collector-1.2.5/lib/buildkite/test_collector/socket_connection.rb:69:in `block in initialize'
	1: from .../lib/ruby/2.7.0/openssl/buffering.rb:125:in `readpartial'
.../lib/ruby/2.7.0/openssl/buffering.rb:125:in `sysread': Operation timed out (Errno::ETIMEDOUT)
```

I was able to reproduce the error by disabling my wifi mid run as reported in the issue. This PR fixes the bug under the same conditions.