### PR TITLE
Add ability to pass custom run env to TA API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/bundle
 
 # rspec failure tracking
 .rspec_status

--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -43,13 +43,15 @@ module Buildkite
       attr_accessor :session
       attr_accessor :debug_enabled
       attr_accessor :tracing_enabled
+      attr_accessor :env
     end
 
-    def self.configure(hook:, token: nil, url: nil, debug_enabled: false, tracing_enabled: true)
+    def self.configure(hook:, token: nil, url: nil, debug_enabled: false, tracing_enabled: true, env: {})
       self.api_token = (token || ENV["BUILDKITE_ANALYTICS_TOKEN"])&.strip
       self.url = url || DEFAULT_URL
       self.debug_enabled = debug_enabled || !!(ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"])
       self.tracing_enabled = tracing_enabled
+      self.env = env
 
       self.hook_into(hook)
     end

--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -8,7 +8,7 @@ class Buildkite::TestCollector::CI
   # The analytics env are more specific than the automatic ci platform env.
   # If they've been specified we'll assume the user wants to use that value instead.
   def env
-    ci_env.merge(analytics_env)
+    ci_env.merge(analytics_env).merge(Buildkite::TestCollector.env)
   end
 
   private

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Buildkite::TestCollector::CI do
     let(:debug) { "true" }
     let(:version) { Buildkite::TestCollector::VERSION }
     let(:name) { Buildkite::TestCollector::NAME }
+    let(:test_value) { "test_value" }
 
     before do
       allow(ENV).to receive(:[]).and_call_original
@@ -24,6 +25,14 @@ RSpec.describe Buildkite::TestCollector::CI do
       fake_env("BUILDKITE_BUILD_ID", nil)
       fake_env("GITHUB_RUN_NUMBER", nil)
       fake_env("CIRCLE_BUILD_NUM", nil)
+
+      Buildkite::TestCollector.configure(hook: :rspec, env: { "test" => test_value })
+    end
+
+    it "merges in the custom env" do
+      result = Buildkite::TestCollector::CI.env
+
+      expect(result["test"]).to eq test_value
     end
 
     context "when running on Buildkite" do
@@ -60,7 +69,8 @@ RSpec.describe Buildkite::TestCollector::CI do
           "message" => bk_message,
           "debug" => debug,
           "version" => version,
-          "collector" => name
+          "collector" => name,
+          "test" => test_value,
         })
       end
 
@@ -93,7 +103,8 @@ RSpec.describe Buildkite::TestCollector::CI do
             "execution_name_prefix" => "execution_name_prefix",
             "execution_name_suffix" => "execution_name_suffix",
             "version" => version,
-            "collector" => name
+            "collector" => name,
+            "test" => test_value,
           })
         end
       end
@@ -131,7 +142,8 @@ RSpec.describe Buildkite::TestCollector::CI do
           "number" => gha_run_number,
           "debug" => debug,
           "version" => version,
-          "collector" => name
+          "collector" => name,
+          "test" => test_value,
         })
       end
 
@@ -160,7 +172,8 @@ RSpec.describe Buildkite::TestCollector::CI do
             "message" => message,
             "debug" => debug,
             "version" => version,
-            "collector" => name
+            "collector" => name,
+            "test" => test_value,
           })
         end
       end
@@ -194,7 +207,8 @@ RSpec.describe Buildkite::TestCollector::CI do
           "number" => c_number,
           "debug" => debug,
           "version" => version,
-          "collector" => name
+          "collector" => name,
+          "test" => test_value,
         })
       end
 
@@ -223,7 +237,8 @@ RSpec.describe Buildkite::TestCollector::CI do
             "message" => message,
             "debug" => debug,
             "version" => version,
-            "collector" => name
+            "collector" => name,
+            "test" => test_value,
           })
         end
       end
@@ -244,7 +259,8 @@ RSpec.describe Buildkite::TestCollector::CI do
           "key" => key,
           "debug" => debug,
           "version" => version,
-          "collector" => name
+          "collector" => name,
+          "test" => test_value,
         })
       end
 
@@ -273,7 +289,8 @@ RSpec.describe Buildkite::TestCollector::CI do
             "message" => message,
             "debug" => debug,
             "version" => version,
-            "collector" => name
+            "collector" => name,
+            "test" => test_value,
           })
         end
       end
@@ -292,7 +309,8 @@ RSpec.describe Buildkite::TestCollector::CI do
           "key" => "845ac829-2ab3-4bbb-9e24-3529755a6d37",
           "debug" => debug,
           "version" => version,
-          "collector" => name
+          "collector" => name,
+          "test" => test_value,
         })
       end
 
@@ -321,7 +339,8 @@ RSpec.describe Buildkite::TestCollector::CI do
             "message" => message,
             "debug" => debug,
             "version" => version,
-            "collector" => name
+            "collector" => name,
+            "test" => test_value,
           })
         end
       end

--- a/spec/test_collector_spec.rb
+++ b/spec/test_collector_spec.rb
@@ -2,26 +2,48 @@
 
 RSpec.describe Buildkite::TestCollector do
   context "RSpec" do
+    let(:hook) { :rspec }
+
     it "can configure api_token and url" do
       analytics = Buildkite::TestCollector
       ENV["BUILDKITE_ANALYTICS_TOKEN"] = "MyToken"
 
-      analytics.configure(hook: :rspec)
+      analytics.configure(hook: hook)
 
       expect(analytics.api_token).to eq "MyToken"
       expect(analytics.url).to eq "https://analytics-api.buildkite.com/v1/uploads"
     end
+
+    it "can configure custom env" do
+      analytics = Buildkite::TestCollector
+      env = { test: "test value" }
+
+      analytics.configure(hook: hook, env: env)
+
+      expect(analytics.env).to match env
+    end
   end
 
   context "Minitest" do
+    let(:hook) { :minitest }
+
     it "can configure api_token and url" do
       analytics = Buildkite::TestCollector
       ENV["BUILDKITE_ANALYTICS_TOKEN"] = "MyToken"
 
-      analytics.configure(hook: :minitest)
+      analytics.configure(hook: hook)
 
       expect(analytics.api_token).to eq "MyToken"
       expect(analytics.url).to eq "https://analytics-api.buildkite.com/v1/uploads"
+    end
+
+    it "can configure custom env" do
+      analytics = Buildkite::TestCollector
+      env = { test: "test value" }
+
+      analytics.configure(hook: hook, env: env)
+
+      expect(analytics.env).to match env
     end
   end
 


### PR DESCRIPTION
As we experiment with new TA features we need a way to send through experimental environment variables. Rather than building against experimental TA branches we can send the custom env using config in our `spec_helper.rb`

Specify custom env with:
```
Buildkite::TestCollector.configure(hook: :rspec, env: { ... })
```