### PR TITLE
Cope with the gem being loaded but not configured when using minitest

### DIFF
--- a/lib/buildkite/test_collector/minitest_plugin/reporter.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/reporter.rb
@@ -11,8 +11,10 @@ module Buildkite::TestCollector::MinitestPlugin
     def record(result)
       super
 
-      if trace = Buildkite::TestCollector.uploader.traces[result.source_location]
-        Buildkite::TestCollector.session&.write_result(trace)
+      if Buildkite::TestCollector.uploader
+        if trace = Buildkite::TestCollector.uploader.traces[result.source_location]
+          Buildkite::TestCollector.session&.write_result(trace)
+        end
       end
     end
 


### PR DESCRIPTION
This problem was introduced in  2eb068dda0a7cf00fdaa644d3204462b5588f2ad.

In our test pipeline, we include the `test-collector-ruby` gem in our `:test` Gemfile group but only configure it to run on certain builds. So we have code like this:

```rb
# Gemfile
group :test do
  gem "buildkite-test_collector", "~> 1.2.5", require: false
end
```

```rb
# test_helper.rb
if !!ENV["BUILDKITE_ANALYTICS_ENABLED"]
  require "buildkite/test_collector"
  Buildkite::TestCollector.configure(hook: :minitest)
end
```

If `BUILDKITE_ANALYTICS_ENABLED` is not set then we never call `configure` and this piece of code is never run:

```rb
# lib/buildkite/test_collector/library_hooks/minitest.rb
Buildkite::TestCollector.uploader = Buildkite::TestCollector::Uploader
```

So `Buildkite::TestCollector.uploader` is nil and this code falls over:

```rb
if trace = Buildkite::TestCollector.uploader.traces[result.source_location]
  Buildkite::TestCollector.session&.write_result(trace)
end
```

This change just wraps that in a test to see if `Buildkite::TestCollector.uploader` is set.