### PR TITLE
Add ability to write test results to a file

### DIFF
--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -43,14 +43,16 @@ module Buildkite
       attr_accessor :session
       attr_accessor :debug_enabled
       attr_accessor :tracing_enabled
+      attr_accessor :artifact_path
       attr_accessor :env
     end
 
-    def self.configure(hook:, token: nil, url: nil, debug_enabled: false, tracing_enabled: true, env: {})
+    def self.configure(hook:, token: nil, url: nil, debug_enabled: false, tracing_enabled: true, artifact_path: nil, env: {})
       self.api_token = (token || ENV["BUILDKITE_ANALYTICS_TOKEN"])&.strip
       self.url = url || DEFAULT_URL
       self.debug_enabled = debug_enabled || !!(ENV["BUILDKITE_ANALYTICS_DEBUG_ENABLED"])
       self.tracing_enabled = tracing_enabled
+      self.artifact_path = artifact_path
       self.env = env
 
       self.hook_into(hook)


### PR DESCRIPTION
### Description

This PR adds the functionality to create a gzipped json file that contains the traces for an rspec test suite. The file is saved to a location specified by a new config param. Perhaps this could also become an environment variable later, but this is just a first cut of this idea, and mostly used for testing. 

It shouldn't affect any current functionality of the gem, as the param defaults to nil. 

### Context

This functionality is added in support of testing [PR #10671](https://github.com/buildkite/buildkite/pull/10671), which adds the ability to ingest test results for analytics from an artifact. This creates the artifact for testing purposes. I haven't added any tests, or looked into minitest support for this reason. 

### Verification

I tried this out locally and verified that the appropriate file was created 

### Deployment

Will do a separate PR for a new release with these changes 

### Rollback

Customers can use old releases if this one doesn't work
