### PR TITLE
[PIE-1365] Update ruby collector API payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.3.2
+
+- Update collector argument in the Analytics::API payload #170 - @KatieWright26
+
 ## v1.3.1
 
 - Cope with the gem being loaded but not configured when using minitest #165 - @billhorsman

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    buildkite-test_collector (1.3.1)
+    buildkite-test_collector (1.3.2)
       activesupport (>= 4.2)
       websocket (~> 1.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4)
+    activesupport (7.0.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -17,7 +17,7 @@ GEM
     diff-lcs (1.4.4)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.16.3)
+    minitest (5.17.0)
     rake (13.0.6)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)

--- a/README.md
+++ b/README.md
@@ -121,12 +121,17 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/buildk
 
 ## Deploying
 
-1. Bump the version in `version.rb` and run `bundle` to update the `Gemfile.lock`
-1. Update the CHANGELOG.md with your new version and a description of the changes.
-
-Once your PR with your changes is on `main`:
+1. Bump the version in `version.rb` and run `bundle` to update the `Gemfile.lock`.
+1. Update the CHANGELOG.md with your new version and a description of your changes.
+1. Git tag your changes and push
+```
+git tag v.x.x.x
+git push --tags
+```
+Once your PR is merged to `main`:
 
 1. Run `rake release` from `main` and use the rubygems credentials in 1Password.
+1. Create a [new release in github](https://github.com/buildkite/test-collector-ruby/releases).
 1. Bump the gem in [buildkite/buildkite](https://github.com/buildkite/buildkite).
 
 ## 📜 MIT License

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ See [DESIGN.md](DESIGN.md) for an overview of the design of this gem.
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/buildkite/test-collector-ruby
 
-## Deploying
+## 🚀 Releasing
 
 1. Bump the version in `version.rb` and run `bundle` to update the `Gemfile.lock`.
 1. Update the CHANGELOG.md with your new version and a description of your changes.
@@ -130,9 +130,8 @@ git push --tags
 ```
 Once your PR is merged to `main`:
 
-1. Run `rake release` from `main` and use the rubygems credentials in 1Password.
+1. Run `rake release` from `main`.
 1. Create a [new release in github](https://github.com/buildkite/test-collector-ruby/releases).
-1. Bump the gem in [buildkite/buildkite](https://github.com/buildkite/buildkite).
 
 ## 📜 MIT License
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ See [DESIGN.md](DESIGN.md) for an overview of the design of this gem.
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/buildkite/test-collector-ruby
 
+## Deploying
+
+1. Bump the version in `version.rb` and run `bundle` to update the `Gemfile.lock`
+1. Update the CHANGELOG.md with your new version and a description of the changes.
+
+Once your PR with your changes is on `main`:
+
+1. Run `rake release` from `main` and use the rubygems credentials in 1Password.
+1. Bump the gem in [buildkite/buildkite](https://github.com/buildkite/buildkite).
+
 ## 📜 MIT License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -38,7 +38,7 @@ class Buildkite::TestCollector::CI
       "execution_name_prefix" => ENV["BUILDKITE_ANALYTICS_EXECUTION_NAME_PREFIX"],
       "execution_name_suffix" => ENV["BUILDKITE_ANALYTICS_EXECUTION_NAME_SUFFIX"],
       "version" => Buildkite::TestCollector::VERSION,
-      "collector" => Buildkite::TestCollector::NAME,
+      "collector" => "ruby-#{Buildkite::TestCollector::NAME}",
     }.compact
   end
 

--- a/lib/buildkite/test_collector/version.rb
+++ b/lib/buildkite/test_collector/version.rb
@@ -2,7 +2,7 @@
 
 module Buildkite
   module TestCollector
-    VERSION = "1.3.1"
+    VERSION = "1.3.2"
     NAME = "buildkite-test_collector"
   end
 end

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Buildkite::TestCollector::CI do
     let(:message) { "bananas are tasty" }
     let(:debug) { "true" }
     let(:version) { Buildkite::TestCollector::VERSION }
-    let(:name) { Buildkite::TestCollector::NAME }
+    let(:name) { "ruby-#{Buildkite::TestCollector::NAME}" }
     let(:test_value) { "test_value" }
 
     before do


### PR DESCRIPTION
This PR tweaks the collector name passed to the Analytics::API so that we can collect accurate information about which collectors are in use by our customers. It is linked to this [piece of work in linear](https://linear.app/buildkite/issue/PIE-435/store-collector-type-junit-rspec-etc).

This PR also adds instructions for deploying this collector, which is consistent with our other test-collectors.

[PIE-1365](https://linear.app/buildkite/issue/PIE-1365/update-ruby-collector-name-to-be-consistent-with-other-collectors)