### PR TITLE
[PIE-1387] Send `failure_expanded` from minitest

### DIFF
--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -72,7 +72,7 @@ module Buildkite::TestCollector::MinitestPlugin
     end
 
     def failure_reason
-      @failure_reason ||= example.failure&.message
+      @failure_reason ||= example.failure&.message&.split("\n")&.first
     end
 
     def failure_expanded

--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -70,14 +70,14 @@ module Buildkite::TestCollector::MinitestPlugin
     end
 
     def failure_reason
-      @failure_reason ||= example.failure&.message&.split("\n")&.first
+      @failure_reason ||= strip_invalid_utf8_chars(example.failure&.message)&.split("\n")&.first
     end
 
     def failure_expanded
       @failure_expanded ||= example.failures.map.with_index do |failure, index|
         # remove the first line of message from the first failure
         # to avoid duplicate line in Test Analytics UI
-        messages = failure.message.split("\n")
+        messages = strip_invalid_utf8_chars(failure.message).split("\n")
         messages = messages[1..] if index.zero?
 
         {

--- a/spec/test_collector/minitest_plugin/trace_spec.rb
+++ b/spec/test_collector/minitest_plugin/trace_spec.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
 require "buildkite/test_collector/minitest_plugin/trace"
+require "minitest"
 
 RSpec.describe Buildkite::TestCollector::MinitestPlugin::Trace do
-  subject(:trace) { Buildkite::TestCollector::MinitestPlugin::Trace.new(result, history: history) }
-  let(:result) { double("Result", name: "test_it_passes", test_it_passes: nil, result_code: 'F', failure: failure, failures: [failure]) }
-  let(:failure) { double("Failure", message: message, backtrace: backtrace)}
-  let(:message) { "test for invalid character'\xC8'\n    Expected: true\n    Actual: false" }
+  subject(:trace) { Buildkite::TestCollector::MinitestPlugin::Trace.new(example, history: history) }
+  let(:example) { double("Minitest::Test", name: "test_it_passes", test_it_passes: nil, result_code: 'F', failure: failure, failures: [failure, another_failure]) }
+
+  # failure is either Minitest::Assertion or Minitest::UnexpectedError object. 
+  # ref: https://github.com/minitest/minitest/blob/master/lib/minitest/test.rb#L198
+  let(:failure) { instance_double(Minitest::Assertion, message: "test for invalid character'\xC8'\n    Expected: true\n    Actual: false", backtrace: backtrace) }
+  let(:another_failure) { instance_double(Minitest::Assertion, message: "another test\n    Expected thing to be truthy.", backtrace: backtrace) }
+
   let(:backtrace) { [
     '# ./lib/test/test.rb:5:in',
     '# ./lib/test/test.rb:15:in',
@@ -53,15 +58,25 @@ RSpec.describe Buildkite::TestCollector::MinitestPlugin::Trace do
     end
 
     describe "failure_expanded" do
-      it "is not empty" do
+      it "contains all failures" do
         failure_expanded = trace.as_hash[:failure_expanded]
-        expect(failure_expanded).not_to be_empty
+        expect(failure_expanded.count).to eq(2)
       end
 
-      it "contains the remaining lines of failure message" do
-        failure_expanded = trace.as_hash[:failure_expanded][0][:expanded].to_s
-        expect(failure_expanded).not_to include("test for invalid character")
-        expect(failure_expanded).to include("Expected: true", "Actual: false")
+      it "contains expanded message and backtrace for each failure" do
+        failure_expanded = trace.as_hash[:failure_expanded]
+        expect(failure_expanded).to all( include(:expanded, backtrace: backtrace) )
+      end
+
+      it "does not contain the first line of failure message for first failure" do
+        first_failure = trace.as_hash[:failure_expanded][0][:expanded].to_s
+        expect(first_failure).not_to include("test for invalid character")
+        expect(first_failure).to include("Expected: true", "Actual: false")
+      end
+
+      it "contains the all lines of failure message for the other failures" do
+        another_failure = trace.as_hash[:failure_expanded][1][:expanded].to_s
+        expect(another_failure).to include("another test","Expected thing to be truthy.")
       end
     end
 

--- a/spec/test_collector/minitest_plugin/trace_spec.rb
+++ b/spec/test_collector/minitest_plugin/trace_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Buildkite::TestCollector::MinitestPlugin::Trace do
     end
 
     describe "failure_expanded" do
-      it "does not empty" do
+      it "is not empty" do
         failure_expanded = trace.as_hash[:failure_expanded]
         expect(failure_expanded).not_to be_empty
       end

--- a/spec/test_collector/minitest_plugin/trace_spec.rb
+++ b/spec/test_collector/minitest_plugin/trace_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Buildkite::TestCollector::MinitestPlugin::Trace do
   let(:example) { double("Minitest::Test", name: "test_it_passes", test_it_passes: nil, result_code: 'F', failure: failure, failures: [failure, another_failure]) }
 
   # failure is either Minitest::Assertion or Minitest::UnexpectedError object. 
-  # ref: https://github.com/minitest/minitest/blob/master/lib/minitest/test.rb#L198
+  # ref: https://github.com/minitest/minitest/blob/0984e29995a5c0f4dcf3c185442bcb4f493ed5e3/lib/minitest/test.rb#L198
   let(:failure) { instance_double(Minitest::Assertion, message: "test for invalid character'\xC8'\n    Expected: true\n    Actual: false", backtrace: backtrace) }
   let(:another_failure) { instance_double(Minitest::Assertion, message: "another test\n    Expected thing to be truthy.", backtrace: backtrace) }
 


### PR DESCRIPTION
### Description

There is a bug in minitest collector that causes failure_expanded not to be sent to Test Analytics. (see implementation)

minitest is sending a long failure message as failure_reason.

see an example from my local test:

```
RuntimeError: bang!!! 💥
    /Users/naufanrizal/Repositories/minitest-example/test/minitest/test_example.rb:19:in `explode'
    /Users/naufanrizal/Repositories/minitest-example/test/minitest/test_example.rb:8:in `block (2 levels) in <top (required)>'
```

### Context

We want to limit the length of `failure_reason` that can be stored by Test Analytics in the upcoming changes. Therefore, we need to split the failure messages into a short summary that goes into `failure_reason` and the detail that goes into `failure_expanded`

### Changes
1. send the first line of failure message as `failure_reason`
2. send the `failure_expanded` to Test Analytics by removing the first line of failure message from the first failure to avoid duplicate lines in the Test Analytics UI

### Verification
I tested locally by creating a ruby gem scaffold (`bundle gem`) with `minitest` and adding a local build of `build-test_collector` to the `Gemfile`. I then configured the test collector as per [doc](https://buildkite.com/docs/test-analytics/ruby-collectors#minitest-collector) and ran the minitest by pointing to the local `buildkite` app.  


### Deployment
publish to RubyGems in a separate PR

### Rollback
use old releases if this one doesn't work
