### PR TITLE
Batch Upload API requests for rspec

### DIFF
--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -31,6 +31,7 @@ require_relative "test_collector/object"
 require_relative "test_collector/tracer"
 require_relative "test_collector/socket_connection"
 require_relative "test_collector/socket_session"
+require_relative "test_collector/session"
 
 module Buildkite
   module TestCollector

--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -35,6 +35,7 @@ require_relative "test_collector/socket_session"
 module Buildkite
   module TestCollector
     DEFAULT_URL = "https://analytics-api.buildkite.com/v1/uploads"
+    DEFAULT_UPLOAD_BATCH_SIZE = 500
 
     class << self
       attr_accessor :api_token
@@ -45,6 +46,7 @@ module Buildkite
       attr_accessor :tracing_enabled
       attr_accessor :artifact_path
       attr_accessor :env
+      attr_accessor :batch_size
     end
 
     def self.configure(hook:, token: nil, url: nil, debug_enabled: false, tracing_enabled: true, artifact_path: nil, env: {})
@@ -54,7 +56,7 @@ module Buildkite
       self.tracing_enabled = tracing_enabled
       self.artifact_path = artifact_path
       self.env = env
-
+      self.batch_size = ENV.fetch("BUILDKITE_ANALYTICS_UPLOAD_BATCH_SIZE") { DEFAULT_UPLOAD_BATCH_SIZE }.to_i
       self.hook_into(hook)
     end
 

--- a/lib/buildkite/test_collector/http_client.rb
+++ b/lib/buildkite/test_collector/http_client.rb
@@ -28,6 +28,28 @@ module Buildkite::TestCollector
       http.request(contact)
     end
 
+    def post_json(data)
+      contact_uri = URI.parse(url)
+
+      http = Net::HTTP.new(contact_uri.host, contact_uri.port)
+      http.use_ssl = contact_uri.scheme == "https"
+
+      contact = Net::HTTP::Post.new(contact_uri.path, {
+        "Authorization" => authorization_header,
+        "Content-Type" => "application/json",
+      })
+
+      data_set = data.map(&:as_hash)
+
+      contact.body = {
+        run_env: Buildkite::TestCollector::CI.env,
+        format: "json",
+        data: data_set
+      }.to_json
+
+      http.request(contact)
+    end
+
     private
 
     attr :url

--- a/lib/buildkite/test_collector/library_hooks/rspec.rb
+++ b/lib/buildkite/test_collector/library_hooks/rspec.rb
@@ -11,8 +11,6 @@ Buildkite::TestCollector.uploader = Buildkite::TestCollector::Uploader
 RSpec.configure do |config|
   config.before(:suite) do
     config.add_formatter Buildkite::TestCollector::RSpecPlugin::Reporter
-
-    Buildkite::TestCollector.safe { Buildkite::TestCollector::Uploader.configure }
   end
 
   config.around(:each) do |example|

--- a/lib/buildkite/test_collector/session.rb
+++ b/lib/buildkite/test_collector/session.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Buildkite::TestCollector
+  class Session
+    UPLOAD_THREAD_TIMEOUT = 60
+    UPLOAD_SESSION_TIMEOUT = 60
+    UPLOAD_API_MAX_RESULTS = 5000
+
+    def initialize
+      @send_queue_ids = []
+      @upload_threads = []
+    end
+
+    def add_example_to_send_queue(id)
+      @send_queue_ids << id
+
+      if @send_queue_ids.size >= Buildkite::TestCollector.batch_size
+        send_ids = @send_queue_ids.shift(Buildkite::TestCollector.batch_size)
+        upload_data(send_ids)
+      end
+    end
+
+    def send_remaining_data
+      return if @send_queue_ids.empty?
+
+      upload_data(@send_queue_ids)
+    end
+
+    def close
+      # There are two thread joins here, because the inner join will wait up to
+      # UPLOAD_THREAD_TIMEOUT seconds PER thread that is uploading data, i.e.
+      # n_threads x UPLOAD_THREAD_TIMEOUT latency if Buildkite happens to be
+      # down. By wrapping that in an outer thread join with the
+      # UPLOAD_SESSION_TIMEOUT, we ensure that we only wait a max of
+      # UPLOAD_SESSION_TIMEOUT seconds before the session exits.
+      Thread.new do
+        @upload_threads.each { |t| t.join(UPLOAD_THREAD_TIMEOUT) }
+      end.join(UPLOAD_SESSION_TIMEOUT)
+
+      @upload_threads.each { |t| t&.kill }
+    end
+
+    private
+
+    def upload_data(ids)
+      data = Buildkite::TestCollector.uploader.traces.values_at(*ids).compact
+
+      # we do this in batches of UPLOAD_API_MAX_RESULTS in case the number of
+      # results exceeds this due to a bug, or user error in configuring the
+      # batch size
+      data.each_slice(UPLOAD_API_MAX_RESULTS) do |batch|
+        new_thread = Buildkite::TestCollector::Uploader.upload(batch)
+        @upload_threads << new_thread if new_thread
+      end
+    end
+  end
+end

--- a/lib/buildkite/test_collector/uploader.rb
+++ b/lib/buildkite/test_collector/uploader.rb
@@ -2,6 +2,8 @@
 
 module Buildkite::TestCollector
   class Uploader
+    MAX_UPLOAD_ATTEMPTS = 3
+
     def self.traces
       @traces ||= {}
     end
@@ -10,6 +12,14 @@ module Buildkite::TestCollector
       URI::InvalidURIError,
       Net::HTTPBadResponse,
       Net::HTTPHeaderSyntaxError,
+      Net::ReadTimeout,
+      Net::OpenTimeout,
+      OpenSSL::SSL::SSLError,
+      OpenSSL::SSL::SSLErrorWaitReadable,
+      EOFError
+    ]
+
+    RETRYABLE_UPLOAD_ERRORS = [
       Net::ReadTimeout,
       Net::OpenTimeout,
       OpenSSL::SSL::SSLError,
@@ -53,6 +63,23 @@ module Buildkite::TestCollector
 
     def self.tracer
       Thread.current[:_buildkite_tracer]
+    end
+
+    def self.upload(data)
+      return false unless Buildkite::TestCollector.api_token
+
+      http = Buildkite::TestCollector::HTTPClient.new(Buildkite::TestCollector.url)
+
+      Thread.new do
+        response = begin
+          upload_attempts ||= 0
+          http.post_json(data)
+        rescue *Buildkite::TestCollector::Uploader::RETRYABLE_UPLOAD_ERRORS => e
+          if (upload_attempts += 1) < MAX_UPLOAD_ATTEMPTS
+            retry
+          end
+        end
+      end
     end
   end
 end

--- a/spec/test_collector/http_client_spec.rb
+++ b/spec/test_collector/http_client_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe Buildkite::TestCollector::HTTPClient do
+  subject { described_class.new("buildkite.localhost") }
+
+  let(:example_group) { OpenStruct.new(metadata: { full_description: "i love to eat pies" }) }
+  let(:execution_result) { OpenStruct.new(status: :passed) }
+  let(:example) do
+    OpenStruct.new(
+      example_group: example_group,
+      description: "mince and cheese",
+      id: "12",
+      location: "123 Pie St",
+      execution_result: execution_result
+    )
+  end
+
+  let(:trace) { Buildkite::TestCollector::RSpecPlugin::Trace.new(example, history: "pie lore") }
+
+  let(:http_double) { double("Net::HTTP_double") }
+  let(:post_double) { double("Net::HTTP::Post") }
+
+  let(:request_body) do
+    {
+      "run_env": {
+        "CI": nil,
+        "key": "build-123",
+        "version": "1.5.0",
+        "collector": "ruby-buildkite-test_collector",
+        "test": "test_value"
+      },
+      "format": "json",
+      "data": [{
+        "id": trace.id,
+        "scope": "i love to eat pies",
+        "name": "mince and cheese",
+        "identifier": "12",
+        "location": "123 Pie St",
+        "result": "passed",
+        "failure_expanded": [],
+        "history": "pie lore"
+      }]
+    }
+  end
+
+  before do
+    allow(Net::HTTP).to receive(:new).and_return(http_double)
+    allow(http_double).to receive(:use_ssl=)
+
+    allow(Net::HTTP::Post).to receive(:new).with("buildkite.localhost", {"Authorization"=>"Token token=\"my-cool-token\"", "Content-Type"=>"application/json"}).and_return(post_double)
+
+    allow(ENV).to receive(:[]).and_call_original
+    fake_env("BUILDKITE_ANALYTICS_KEY", "build-123")
+
+    # these have to be reset or these tests will fail on CI
+    fake_env("CI", nil)
+    fake_env("BUILDKITE_BUILD_ID", nil)
+    fake_env("GITHUB_RUN_NUMBER", nil)
+    fake_env("CIRCLE_BUILD_NUM", nil)
+
+    Buildkite::TestCollector.configure(hook: :rspec, token: "my-cool-token", env: { "test" => "test_value" })
+  end
+
+  describe "#post_json" do
+    it "sends the right data" do
+      expect(post_double).to receive(:body=).with(request_body.to_json)
+      expect(http_double).to receive(:request).with(post_double)
+      subject.post_json([trace])
+    end
+  end
+end

--- a/spec/test_collector/session_spec.rb
+++ b/spec/test_collector/session_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+RSpec.describe Buildkite::TestCollector::Session do
+  subject { described_class.new }
+  let(:data) do
+    {
+      "test-1": "test-1-data",
+      "test-2": "test-2-data",
+      "test-3": "test-3-data",
+      "test-4": "test-4-data",
+      "test-5": "test-5-data",
+    }
+  end
+
+  before do
+    Buildkite::TestCollector.uploader = Buildkite::TestCollector::Uploader
+    data.each { |k, v| Buildkite::TestCollector.uploader.traces[k] = v }
+    Buildkite::TestCollector.batch_size = 5
+  end
+
+  describe "#add_example_to_send_queue" do
+    it "adds the example and sends only when batch size is reached" do
+      expect(Buildkite::TestCollector::Uploader).to receive(:upload).once.with(data.values)
+
+      subject.add_example_to_send_queue(:"test-1")
+      subject.add_example_to_send_queue(:"test-2")
+      subject.add_example_to_send_queue(:"test-3")
+      subject.add_example_to_send_queue(:"test-4")
+      subject.add_example_to_send_queue(:"test-5")
+    end
+  end
+
+  describe "#send_remaining_data" do
+    it "sends through remaining examples even when batch size is not reach" do
+      expect(Buildkite::TestCollector::Uploader).to receive(:upload).once.with(data.reject { |k,v| k == :"test-5"}.values)
+
+      subject.add_example_to_send_queue(:"test-1")
+      subject.add_example_to_send_queue(:"test-2")
+      subject.add_example_to_send_queue(:"test-3")
+      subject.add_example_to_send_queue(:"test-4")
+
+      subject.send_remaining_data
+    end
+
+    it "limits upload batch size to UPLOAD_API_MAX_RESULTS" do
+      stub_const("Buildkite::TestCollector::Session::UPLOAD_API_MAX_RESULTS", 1)
+
+      expect(Buildkite::TestCollector::Uploader).to receive(:upload).once.with(["test-1-data"])
+      expect(Buildkite::TestCollector::Uploader).to receive(:upload).once.with(["test-2-data"])
+
+      subject.add_example_to_send_queue(:"test-1")
+      subject.add_example_to_send_queue(:"test-2")
+
+      subject.send_remaining_data
+    end
+  end
+
+  describe "#close" do
+    let(:thread) { Thread.new { sleep(1) } }
+
+    before do
+      stub_const("Buildkite::TestCollector::Session::UPLOAD_SESSION_TIMEOUT", 0.1)
+    end
+
+    it "kills threads after timeout has elapsed" do
+      subject.add_example_to_send_queue(:"test-1")
+      expect(Buildkite::TestCollector::Uploader).to receive(:upload).and_return(thread)
+      subject.send_remaining_data
+
+      subject.close
+      sleep(0.2)
+      expect(thread.alive?).to eq false
+    end
+  end
+end


### PR DESCRIPTION
### Description

This is the first part of [PIE-1436](https://linear.app/buildkite/issue/PIE-1436/drop-support-for-actioncableuploadchannel-from-the-ruby-collector), which will drop ActionCable support from test-collector-ruby. This removes ActionCable support for test suites configured to use RSpec. 

Use of the SocketSession (websocket implementation) is removed from the RSpec config and replaced with a new Session that sends requests in batches via the Upload API. The batch size is configured via a new env variable, `BUILDKITE_ANALYTICS_UPLOAD_BATCH_SIZE`, which defaults to 500. This is configurable mainly to allow ease of testing. 

The implementation of this leverages RSpec [custom formatters](https://rspec.info/documentation/3.9/rspec-core/RSpec/Core/Formatters.html). After every test, we have defined a custom handler called `handle_example`. The method takes the id of the example which has just executed, and stores it in a buffer. Once this buffer reaches the batch size, the trace data associated with the example ids is uploaded to Buildkite via the Upload API. 

After the test suite has finished executing, the `dump_summary` method is called. This sends any outstanding examples to the Upload API. 

The post requests to Upload API are each done in a separate thread, so that sending large payloads of data do not hold up the execution of the test suite. We retry the Upload API request up to 3 times, if the errors we received look to be network related, rather than a result of not being configured correctly, or the particular suite being over its rate limit. 

At the end of the test suite, the test collector will wait up to 60 seconds for any last Upload API requests to finish, before exiting the test suite. 

### Verification & Deployment

This change can be tested locally by checking out this branch and bundling buildkite/buildkite with this checked out repository, then running `BUILDKITE_ANALYTICS_RSPEC_TOKEN=xx-local-analytics-key BUILDKITE_ANALYTICS_UPLOAD_BATCH_SIZE=5 BUILDKITE_BUILD_ID="1" rspec spec/models/webhook` or similar in the buildkite/buildkite repository. 

After merge, my plan is to do another PR to do a pre-release of this change. Then I will create a branch on buildkite/buildkite to run some scheduled builds with the new release, and monitor for any errors or performance degradations. Typically, an rspec job in Buildkite has 300-600 tests, so we'll be creating 1-2 uploads per rspec job. 

Minitest to come after this!