### PR TITLE
Rename session to socket session

### DIFF
--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -30,7 +30,7 @@ require_relative "test_collector/network"
 require_relative "test_collector/object"
 require_relative "test_collector/tracer"
 require_relative "test_collector/socket_connection"
-require_relative "test_collector/session"
+require_relative "test_collector/socket_session"
 
 module Buildkite
   module TestCollector

--- a/lib/buildkite/test_collector/socket_connection.rb
+++ b/lib/buildkite/test_collector/socket_connection.rb
@@ -73,7 +73,7 @@ module Buildkite::TestCollector
           end
         end
       # These get re-raise from session, we should fail gracefully
-      rescue *Buildkite::TestCollector::Session::DISCONNECTED_EXCEPTIONS => e
+      rescue *Buildkite::TestCollector::SocketSession::DISCONNECTED_EXCEPTIONS => e
         Buildkite::TestCollector.logger.error("We could not establish a connection with Buildkite Test Analytics. The error was: #{e.message}. If this is a problem, please contact support.")
       rescue EOFError, OpenSSL::SSL::SSLError => e
         # https://github.com/buildkite/test-collector-ruby/pull/147#issuecomment-1250485611

--- a/lib/buildkite/test_collector/socket_session.rb
+++ b/lib/buildkite/test_collector/socket_session.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Buildkite::TestCollector
-  class Session
+  class SocketSession
     # Picked 75 as the magic timeout number as it's longer than the TCP timeout of 60s 🤷‍♀️
     CONFIRMATION_TIMEOUT = ENV.fetch("BUILDKITE_ANALYTICS_CONFIRMATION_TIMEOUT") { 75 }.to_i
     MAX_RECONNECTION_ATTEMPTS = ENV.fetch("BUILDKITE_ANALYTICS_RECONNECTION_ATTEMPTS") { 3 }.to_i

--- a/lib/buildkite/test_collector/uploader.rb
+++ b/lib/buildkite/test_collector/uploader.rb
@@ -38,7 +38,7 @@ module Buildkite::TestCollector
           json = JSON.parse(response.body)
 
           if (socket_url = json["cable"]) && (channel = json["channel"])
-            Buildkite::TestCollector.session = Buildkite::TestCollector::Session.new(socket_url, http.authorization_header, channel)
+            Buildkite::TestCollector.session = Buildkite::TestCollector::SocketSession.new(socket_url, http.authorization_header, channel)
           end
         else
           request_id = response.to_hash["x-request-id"]

--- a/spec/test_collector/socket_connection_spec.rb
+++ b/spec/test_collector/socket_connection_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Buildkite::TestCollector::SocketConnection do
-  let(:session_double) { instance_double("Buildkite::TestCollector::Session") }
+  let(:session_double) { instance_double("Buildkite::TestCollector::SocketSession") }
   let(:socket_connection) { Buildkite::TestCollector::SocketConnection.new(session_double, "fake_url", {}) }
   let(:ssl_socket_double) { instance_double("OpenSSL::SSL::SSLSocket") }
   let(:tcp_socket_double) { instance_double("TCPSocket") }

--- a/spec/test_collector/socket_session_spec.rb
+++ b/spec/test_collector/socket_session_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe Buildkite::TestCollector::Session do
+RSpec.describe Buildkite::TestCollector::SocketSession do
   let(:socket_double) { instance_double("Buildkite::TestCollector::SocketConnection") }
-  let(:session) { Buildkite::TestCollector::Session.new("fake_url", "fake_auth", "fake_channel") }
+  let(:session) { Buildkite::TestCollector::SocketSession.new("fake_url", "fake_auth", "fake_channel") }
   let(:examples_count) do
     {
       examples: 3,
@@ -26,8 +26,8 @@ RSpec.describe Buildkite::TestCollector::Session do
       "identifier" => "fake_channel"
     }) { @session.handle(socket_double, {"type"=> "confirm_subscription", "identifier"=> "fake_channel"}.to_json) }
 
-    stub_const("Buildkite::TestCollector::Session::WAIT_BETWEEN_RECONNECTIONS", 0)
-    stub_const("Buildkite::TestCollector::Session::CONFIRMATION_TIMEOUT", 5)
+    stub_const("Buildkite::TestCollector::SocketSession::WAIT_BETWEEN_RECONNECTIONS", 0)
+    stub_const("Buildkite::TestCollector::SocketSession::CONFIRMATION_TIMEOUT", 5)
   end
 
   describe "#initalize" do
@@ -196,7 +196,7 @@ RSpec.describe Buildkite::TestCollector::Session do
           if call_count.odd?
             @session.handle(socket_double, {"type"=> "confirm_subscription", "identifier"=> "fake_channel"}.to_json)
           else
-            raise Buildkite::TestCollector::Session::RejectedSubscription
+            raise Buildkite::TestCollector::SocketSession::RejectedSubscription
           end
       }
 


### PR DESCRIPTION
This PR is just a precursor to #174, which switches test-collector-ruby to send upload data via the Upload API rather than the ActionCable websocket for RSpec test suites. 

This PR renames the previous `Session` to `SocketSession` as Minitest is still using the websocket implementation. As PR #174 creates a new `Session` object, the rename was pulled out into a separate PR for clarity of reading PR #174