### PR TITLE
PIE-1478/Remove identifier from trace

### DIFF
--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -50,7 +50,6 @@ module Buildkite::TestCollector::MinitestPlugin
         "#{file_name}:#{line_number}"
       end
     end
-    alias_method :identifier, :location
 
     def file_name
       @file_name ||= File.join('./', source_location[0].delete_prefix(project_dir))

--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -34,7 +34,6 @@ module Buildkite::TestCollector::MinitestPlugin
         id: id,
         scope: example.class.name,
         name: example.name,
-        identifier: identifier,
         location: location,
         file_name: file_name,
         result: result,

--- a/lib/buildkite/test_collector/rspec_plugin/trace.rb
+++ b/lib/buildkite/test_collector/rspec_plugin/trace.rb
@@ -28,7 +28,6 @@ module Buildkite::TestCollector::RSpecPlugin
         id: id,
         scope: example.example_group.metadata[:full_description],
         name: example.description,
-        identifier: example.id,
         location: example.location,
         file_name: file_name,
         result: result,

--- a/spec/test_collector/rspec_plugin/trace_spec.rb
+++ b/spec/test_collector/rspec_plugin/trace_spec.rb
@@ -17,13 +17,6 @@ RSpec.describe Buildkite::TestCollector::RSpecPlugin::Trace do
   end
 
   describe '#as_hash' do
-    it 'removes invalid UTF-8 characters from top level values' do
-      identifier = trace.as_hash[:identifier]
-
-      expect(identifier).to include('test for invalid character')
-      expect(identifier).to be_valid_encoding
-    end
-
     it 'removes invalid UTF-8 characters from nested values' do
       history_json = trace.as_hash[:history].to_json
 


### PR DESCRIPTION
We no longer using identifier in TA and have stopped saving the value in our database. This PR removes identifier from Rspec trace and Minitest trace. We are not going to make a release for this small change.

Ticket: https://linear.app/buildkite/issue/PIE-1478/remove-identifier-from-ruby-test-collector 
Parent ticket: https://linear.app/buildkite/issue/PIE-1427/remove-identifier-from-test-collector-payloads

To verify the change, Rose and I paired together to do an integration test for Rspec.I updated the gemfile on my local buildkite repo to use the local test-collector-ruby gem

- Running rspec test at local not causing any errors
- Records are created in the database, and we can see the runs and executions from the UI
- `identifier` is not included in the S3 file

To verify the changes to the minitest collector, I tested the changes against this PR https://github.com/buildkite/buildkite/pull/11383.
- Running minitest at local not causing any errors
- Records are created in the database, and we can see the runs and executions from the UI
- `identifier` is not included in the S3 file
