### PR TITLE
[PIE-1436] Pre-release Rspec changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v2.0.0.pre
+
+- Major change: RSpec plugin to use HTTP Upload API instead of websocket connection to send test data #174 #175 - @niceking
+- `identifier` field removed from trace #176 - @amybiyuliu
+
 ## v1.5.0
 
 - Send `failure_expanded` from minitest #171 - @nprizal 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    buildkite-test_collector (1.5.0)
+    buildkite-test_collector (2.0.0.pre)
       activesupport (>= 4.2)
       websocket (~> 1.2)
 
@@ -13,11 +13,11 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    concurrent-ruby (1.2.0)
+    concurrent-ruby (1.2.2)
     diff-lcs (1.4.4)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.17.0)
+    minitest (5.18.0)
     rake (13.0.6)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -47,4 +47,4 @@ DEPENDENCIES
   rspec-expectations (~> 3.10)
 
 BUNDLED WITH
-   2.2.22
+   2.3.25

--- a/lib/buildkite/test_collector/version.rb
+++ b/lib/buildkite/test_collector/version.rb
@@ -2,7 +2,7 @@
 
 module Buildkite
   module TestCollector
-    VERSION = "1.5.0"
+    VERSION = "2.0.0.pre"
     NAME = "buildkite-test_collector"
   end
 end

--- a/spec/test_collector/http_client_spec.rb
+++ b/spec/test_collector/http_client_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Buildkite::TestCollector::HTTPClient do
       "run_env": {
         "CI": nil,
         "key": "build-123",
-        "version": "1.5.0",
+        "version": "2.0.0.pre",
         "collector": "ruby-buildkite-test_collector",
         "test": "test_value"
       },
@@ -34,7 +34,6 @@ RSpec.describe Buildkite::TestCollector::HTTPClient do
         "id": trace.id,
         "scope": "i love to eat pies",
         "name": "mince and cheese",
-        "identifier": "12",
         "location": "123 Pie St",
         "result": "passed",
         "failure_expanded": [],


### PR DESCRIPTION
Creating a pre-release for the major changes to the Rspec plugin 

Have given it another integration test locally by running `BUILDKITE_ANALYTICS_RSPEC_TOKEN=xx-local-analytics-key BUILDKITE_ANALYTICS_UPLOAD_BATCH_SIZE=2 BUILDKITE_BUILD_ID="hi" rspec spec/models/admin/goto_spec.rb` and verified that all relevant records and S3 files are created. 