### PR TITLE
Switch minitest to upload api

### DIFF
--- a/lib/buildkite/test_collector/library_hooks/minitest.rb
+++ b/lib/buildkite/test_collector/library_hooks/minitest.rb
@@ -12,4 +12,4 @@ end
 
 Buildkite::TestCollector.enable_tracing!
 
-Buildkite::TestCollector.safe { Buildkite::TestCollector::Uploader.configure }
+Buildkite::TestCollector.session = Buildkite::TestCollector::Session.new


### PR DESCRIPTION
This changes the minitest plugin to use to the Upload API rather than the ActionCable websocket to send test data. 

I used the minitest setup in this branch: https://github.com/buildkite/buildkite/pull/11383 and I ran these two tests:
`BUILDKITE_ANALYTICS_RSPEC_TOKEN=local bin/rails test test/test.rb`
`BUILDKITE_ANALYTICS_RSPEC_TOKEN=local BUILDKITE_ANALYTICS_UPLOAD_BATCH_SIZE=1 bin/rails test test/test.rb`

And everything works as expected, and the right models and S3 files are created. I am fairly confident that this change is fine despite only testing against a small dummy test suite, I thought about finding a minitest customer to get them to try this change out but I'm not sure that's really worth the effort. 

I am not planning on doing a release just for this change, will follow up with a PR that removes all the websocket stuff and do a release then