### PR TITLE
Remove remaning "websocket" references

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,17 +2,7 @@
 
 ## Threads
 
-The Buildkite ruby collector uses websockets and ActionCable to send and
-receive data with Buildkite. Execution information starts transmitting as soon
-as possible, without waiting for the test suite to finish running.
-
-This gem uses 3 ruby threads:
-
-* main thread: acts as the producer. It collects span data from the
-  test suite and enqueues it into the send queue.
-* write thread: acts as the consumer. Removes data from the send queue and
-  sends it to Buildkite.
-* read thread: receives and processes messages from Buildkite.
+The Buildkite ruby collector uses threads to send data to the Upload API in the background. When the test suite has finished running, the collector waits UPLOAD_SESSION_TIMEOUT seconds for the Upload API requests to finish before exiting.
 
 ## Data
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     buildkite-test_collector (2.1.0.pre)
       activesupport (>= 4.2)
-      websocket (~> 1.2)
 
 GEM
   remote: https://rubygems.org/
@@ -34,7 +33,6 @@ GEM
     rspec-support (3.10.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    websocket (1.2.9)
 
 PLATFORMS
   ruby

--- a/buildkite-test_collector.gemspec
+++ b/buildkite-test_collector.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
   spec.add_dependency "activesupport", ">= 4.2"
-  spec.add_dependency "websocket", '~> 1.2'
 
   spec.add_development_dependency "rspec-core", '~> 3.10'
   spec.add_development_dependency "rspec-expectations", '~> 3.10'

--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -8,13 +8,10 @@ end
 require "json"
 require "logger"
 require "net/http"
-require "openssl"
 require "time"
 require "timeout"
 require "tmpdir"
 require "securerandom"
-require "socket"
-require "websocket"
 
 require "active_support/core_ext/object/blank"
 require "active_support/core_ext/hash/indifferent_access"

--- a/lib/buildkite/test_collector/http_client.rb
+++ b/lib/buildkite/test_collector/http_client.rb
@@ -10,24 +10,6 @@ module Buildkite::TestCollector
       @authorization_header = "Token token=\"#{Buildkite::TestCollector.api_token}\""
     end
 
-    def post
-      contact_uri = URI.parse(url)
-
-      http = Net::HTTP.new(contact_uri.host, contact_uri.port)
-      http.use_ssl = contact_uri.scheme == "https"
-
-      contact = Net::HTTP::Post.new(contact_uri.path, {
-        "Authorization" => authorization_header,
-        "Content-Type" => "application/json",
-      })
-      contact.body = {
-        run_env: Buildkite::TestCollector::CI.env,
-        format: "websocket"
-      }.to_json
-
-      http.request(contact)
-    end
-
     def post_json(data)
       contact_uri = URI.parse(url)
 


### PR DESCRIPTION
Getting rid of some stale requirements and references to websockets before general release of v2.X of gem