### PR TITLE
Gzip body of upload request

### DIFF
--- a/buildkite.yaml
+++ b/buildkite.yaml
@@ -5,4 +5,4 @@ steps:
       - "bundle exec rake"
     plugins:
       - docker#v3.7.0:
-          image: ruby:latest
+          image: 445615400570.dkr.ecr.us-east-1.amazonaws.com/ecr-public/docker/library/ruby:3.1.4

--- a/lib/buildkite/test_collector/http_client.rb
+++ b/lib/buildkite/test_collector/http_client.rb
@@ -19,15 +19,24 @@ module Buildkite::TestCollector
       contact = Net::HTTP::Post.new(contact_uri.path, {
         "Authorization" => authorization_header,
         "Content-Type" => "application/json",
+        "Content-Encoding" => "gzip",
       })
 
       data_set = data.map(&:as_hash)
 
-      contact.body = {
+      body = {
         run_env: Buildkite::TestCollector::CI.env,
         format: "json",
         data: data_set
       }.to_json
+
+      compressed_body = StringIO.new
+
+      writer = Zlib::GzipWriter.new(compressed_body)
+      writer.write(body)
+      writer.close
+
+      contact.body = compressed_body.string
 
       http.request(contact)
     end

--- a/spec/test_collector/http_client_spec.rb
+++ b/spec/test_collector/http_client_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Buildkite::TestCollector::HTTPClient do
     allow(Net::HTTP).to receive(:new).and_return(http_double)
     allow(http_double).to receive(:use_ssl=)
 
-    allow(Net::HTTP::Post).to receive(:new).with("buildkite.localhost", {"Authorization"=>"Token token=\"my-cool-token\"", "Content-Type"=>"application/json"}).and_return(post_double)
+    allow(Net::HTTP::Post).to receive(:new).with("buildkite.localhost", {"Authorization"=>"Token token=\"my-cool-token\"", "Content-Encoding"=>"gzip", "Content-Type"=>"application/json"}).and_return(post_double)
 
     allow(ENV).to receive(:[]).and_call_original
     fake_env("BUILDKITE_ANALYTICS_KEY", "build-123")

--- a/spec/test_collector/http_client_spec.rb
+++ b/spec/test_collector/http_client_spec.rb
@@ -39,7 +39,17 @@ RSpec.describe Buildkite::TestCollector::HTTPClient do
         "failure_expanded": [],
         "history": "pie lore"
       }]
-    }
+      }.to_json
+  end
+
+  let(:compressed_body) do
+    str = StringIO.new
+
+    writer = Zlib::GzipWriter.new(str)
+    writer.write(request_body)
+    writer.close
+
+    str.string
   end
 
   before do
@@ -62,7 +72,7 @@ RSpec.describe Buildkite::TestCollector::HTTPClient do
 
   describe "#post_json" do
     it "sends the right data" do
-      expect(post_double).to receive(:body=).with(request_body.to_json)
+      expect(post_double).to receive(:body=).with(compressed_body)
       expect(http_double).to receive(:request).with(post_double)
       subject.post_json([trace])
     end


### PR DESCRIPTION
Gzip the payload for Upload API requests, and set Content-Encoding header so the server knows how to decode the payload. Relevant changes to bk/bk to support this is in [PR #12006](https://github.com/buildkite/buildkite/pull/12006)