### PR TITLE
Safeguard SecureRandom.uuid

### DIFF
--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -11,7 +11,6 @@ require "net/http"
 require "time"
 require "timeout"
 require "tmpdir"
-require "securerandom"
 
 require "active_support/core_ext/object/blank"
 require "active_support/core_ext/hash/indifferent_access"
@@ -26,6 +25,7 @@ require_relative "test_collector/network"
 require_relative "test_collector/object"
 require_relative "test_collector/tracer"
 require_relative "test_collector/session"
+require_relative "test_collector/uuid"
 
 module Buildkite
   module TestCollector

--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -21,7 +21,7 @@ class Buildkite::TestCollector::CI
 
     {
       "CI" => nil,
-      "key" => SecureRandom.uuid,
+      "key" => Buildkite::TestCollector::Uuid.call,
     }
   end
 
@@ -44,7 +44,7 @@ class Buildkite::TestCollector::CI
   def generic
     {
       "CI" => "generic",
-      "key" => SecureRandom.uuid,
+      "key" => Buildkite::TestCollector::Uuid.call,
     }
   end
 

--- a/lib/buildkite/test_collector/library_hooks/rspec.rb
+++ b/lib/buildkite/test_collector/library_hooks/rspec.rb
@@ -30,7 +30,7 @@ RSpec.configure do |config|
 
   config.after(:suite) do
     if Buildkite::TestCollector.artifact_path
-      filename = File.join(Buildkite::TestCollector.artifact_path, "buildkite-test-collector-rspec-#{SecureRandom.uuid}.json.gz")
+      filename = File.join(Buildkite::TestCollector.artifact_path, "buildkite-test-collector-rspec-#{Buildkite::TestCollector::Uuid.call}.json.gz")
       data_set = { results: Buildkite::TestCollector.uploader.traces.values.map(&:as_hash) }
       File.open(filename, "wb") do |f|
         gz = Zlib::GzipWriter.new(f)

--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -16,7 +16,7 @@ module Buildkite::TestCollector::MinitestPlugin
     FILE_PATH_REGEX = /^(.*?\.(rb|feature))/
 
     def initialize(example, history:)
-      @id = SecureRandom.uuid
+      @id = Buildkite::TestCollector::Uuid.call
       @example = example
       @history = history
     end

--- a/lib/buildkite/test_collector/rspec_plugin/trace.rb
+++ b/lib/buildkite/test_collector/rspec_plugin/trace.rb
@@ -8,7 +8,7 @@ module Buildkite::TestCollector::RSpecPlugin
     FILE_PATH_REGEX = /^(.*?\.(rb|feature))/
 
     def initialize(example, history:, failure_reason: nil, failure_expanded: [])
-      @id = SecureRandom.uuid
+      @id = Buildkite::TestCollector::Uuid.call
       @example = example
       @history = history
       @failure_reason = failure_reason

--- a/lib/buildkite/test_collector/uuid.rb
+++ b/lib/buildkite/test_collector/uuid.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+class Buildkite::TestCollector::Uuid
+  GET_UUID = SecureRandom.method(:uuid)
+  private_constant :GET_UUID
+
+  def self.call
+    GET_UUID.call
+  end
+end

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Buildkite::TestCollector::CI do
   describe ".env" do
     let(:ci) { "true" }
-    let(:key) { SecureRandom.uuid }
+    let(:key) { Buildkite::TestCollector::Uuid.call }
     let(:url) { "http://example.com" }
     let(:branch) { "not-main" }
     let(:sha) { "a2c5ef54" }


### PR DESCRIPTION
This is a follow up to https://github.com/buildkite/test-collector-ruby/issues/131.

Our test suite stubs `SecureRandom.uuid` in various places so enabling `[test-collector-ruby](https://github.com/buildkite/test-collector-ruby)` breaks our test suite.

We thought this was fixed with https://github.com/buildkite/test-collector-ruby/pull/133 but we still see this happening.

I believe the best approach is to just safe guard `SecureRandom.uuid` by storing a private reference to the method.

