### PR TITLE
Fix nil pointer

### DIFF
--- a/lib/buildkite/test_collector/minitest_plugin/reporter.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/reporter.rb
@@ -21,8 +21,10 @@ module Buildkite::TestCollector::MinitestPlugin
     def report
       super
 
-      Buildkite::TestCollector.session.send_remaining_data
-      Buildkite::TestCollector.session.close
+      if Buildkite::TestCollector.session
+        Buildkite::TestCollector.session.send_remaining_data
+        Buildkite::TestCollector.session.close
+      end
     end
   end
 end


### PR DESCRIPTION
I'm not entirely sure about this fix but we still get an error if we don't initialize the plugin locally.

<img width="1512" alt="Screenshot 2023-05-02 at 14 16 54" src="https://user-images.githubusercontent.com/3799140/235677924-a77868f2-458a-4292-bd8a-016ffc3d96c8.png">

Potentially related to https://github.com/buildkite/test-collector-ruby/pull/125.
