### PR TITLE
Rescue standard error

### DIFF
--- a/lib/buildkite/test_collector/uploader.rb
+++ b/lib/buildkite/test_collector/uploader.rb
@@ -24,7 +24,8 @@ module Buildkite::TestCollector
       Net::OpenTimeout,
       OpenSSL::SSL::SSLError,
       OpenSSL::SSL::SSLErrorWaitReadable,
-      EOFError
+      EOFError,
+      Errno::ETIMEDOUT
     ]
 
     def self.tracer

--- a/lib/buildkite/test_collector/uploader.rb
+++ b/lib/buildkite/test_collector/uploader.rb
@@ -45,6 +45,8 @@ module Buildkite::TestCollector
           if (upload_attempts += 1) < MAX_UPLOAD_ATTEMPTS
             retry
           end
+        rescue StandardError => e
+          $stderr.puts "#{Buildkite::TestCollector::NAME} #{Buildkite::TestCollector::VERSION} experienced an error when sending your data, you may be missing some executions for this run."
         end
       end
     end


### PR DESCRIPTION
Rescuing network connection errors are much too whack-a-mole for my liking so I'm going to add the specific one raised in Issue #190 to the retryable list, but then also rescue from StandardError (like we did with the websocket implementation) so any further issues in the future don't bubble up and cause builds to fail.