### PR TITLE
Stop sending execution id

### DIFF
--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -11,7 +11,6 @@ require "net/http"
 require "time"
 require "timeout"
 require "tmpdir"
-require "securerandom"
 
 require "active_support/core_ext/object/blank"
 require "active_support/core_ext/hash/indifferent_access"
@@ -26,6 +25,7 @@ require_relative "test_collector/network"
 require_relative "test_collector/object"
 require_relative "test_collector/tracer"
 require_relative "test_collector/session"
+require_relative "test_collector/uuid"
 
 module Buildkite
   module TestCollector

--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -21,7 +21,7 @@ class Buildkite::TestCollector::CI
 
     {
       "CI" => nil,
-      "key" => SecureRandom.uuid,
+      "key" => Buildkite::TestCollector::Uuid.call,
     }
   end
 
@@ -44,7 +44,7 @@ class Buildkite::TestCollector::CI
   def generic
     {
       "CI" => "generic",
-      "key" => SecureRandom.uuid,
+      "key" => Buildkite::TestCollector::Uuid.call,
     }
   end
 

--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -21,7 +21,7 @@ class Buildkite::TestCollector::CI
 
     {
       "CI" => nil,
-      "key" => Buildkite::TestCollector::Uuid.call,
+      "key" => Buildkite::TestCollector::UUID.call,
     }
   end
 
@@ -44,7 +44,7 @@ class Buildkite::TestCollector::CI
   def generic
     {
       "CI" => "generic",
-      "key" => Buildkite::TestCollector::Uuid.call,
+      "key" => Buildkite::TestCollector::UUID.call,
     }
   end
 

--- a/lib/buildkite/test_collector/library_hooks/rspec.rb
+++ b/lib/buildkite/test_collector/library_hooks/rspec.rb
@@ -30,7 +30,7 @@ RSpec.configure do |config|
 
   config.after(:suite) do
     if Buildkite::TestCollector.artifact_path
-      filename = File.join(Buildkite::TestCollector.artifact_path, "buildkite-test-collector-rspec-#{SecureRandom.uuid}.json.gz")
+      filename = File.join(Buildkite::TestCollector.artifact_path, "buildkite-test-collector-rspec-#{Buildkite::TestCollector::Uuid.call}.json.gz")
       data_set = { results: Buildkite::TestCollector.uploader.traces.values.map(&:as_hash) }
       File.open(filename, "wb") do |f|
         gz = Zlib::GzipWriter.new(f)

--- a/lib/buildkite/test_collector/library_hooks/rspec.rb
+++ b/lib/buildkite/test_collector/library_hooks/rspec.rb
@@ -30,7 +30,7 @@ RSpec.configure do |config|
 
   config.after(:suite) do
     if Buildkite::TestCollector.artifact_path
-      filename = File.join(Buildkite::TestCollector.artifact_path, "buildkite-test-collector-rspec-#{Buildkite::TestCollector::Uuid.call}.json.gz")
+      filename = File.join(Buildkite::TestCollector.artifact_path, "buildkite-test-collector-rspec-#{Buildkite::TestCollector::UUID.call}.json.gz")
       data_set = { results: Buildkite::TestCollector.uploader.traces.values.map(&:as_hash) }
       File.open(filename, "wb") do |f|
         gz = Zlib::GzipWriter.new(f)

--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -4,7 +4,7 @@ module Buildkite::TestCollector::MinitestPlugin
   class Trace
     attr_accessor :example
     attr_writer :failure_reason, :failure_expanded
-    attr_reader :id, :history
+    attr_reader :history
 
     RESULT_CODES = {
       '.' => 'passed',
@@ -16,7 +16,6 @@ module Buildkite::TestCollector::MinitestPlugin
     FILE_PATH_REGEX = /^(.*?\.(rb|feature))/
 
     def initialize(example, history:)
-      @id = Buildkite::TestCollector::UUID.call
       @example = example
       @history = history
     end
@@ -31,7 +30,6 @@ module Buildkite::TestCollector::MinitestPlugin
 
     def as_hash
       strip_invalid_utf8_chars(
-        id: id,
         scope: example.class.name,
         name: example.name,
         location: location,

--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -16,7 +16,7 @@ module Buildkite::TestCollector::MinitestPlugin
     FILE_PATH_REGEX = /^(.*?\.(rb|feature))/
 
     def initialize(example, history:)
-      @id = Buildkite::TestCollector::Uuid.call
+      @id = Buildkite::TestCollector::UUID.call
       @example = example
       @history = history
     end

--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -16,7 +16,7 @@ module Buildkite::TestCollector::MinitestPlugin
     FILE_PATH_REGEX = /^(.*?\.(rb|feature))/
 
     def initialize(example, history:)
-      @id = SecureRandom.uuid
+      @id = Buildkite::TestCollector::Uuid.call
       @example = example
       @history = history
     end

--- a/lib/buildkite/test_collector/rspec_plugin/trace.rb
+++ b/lib/buildkite/test_collector/rspec_plugin/trace.rb
@@ -3,12 +3,11 @@
 module Buildkite::TestCollector::RSpecPlugin
   class Trace
     attr_accessor :example, :failure_reason, :failure_expanded
-    attr_reader :id, :history
+    attr_reader :history
 
     FILE_PATH_REGEX = /^(.*?\.(rb|feature))/
 
     def initialize(example, history:, failure_reason: nil, failure_expanded: [])
-      @id = Buildkite::TestCollector::UUID.call
       @example = example
       @history = history
       @failure_reason = failure_reason
@@ -25,7 +24,6 @@ module Buildkite::TestCollector::RSpecPlugin
 
     def as_hash
       strip_invalid_utf8_chars(
-        id: id,
         scope: example.example_group.metadata[:full_description],
         name: example.description,
         location: example.location,

--- a/lib/buildkite/test_collector/rspec_plugin/trace.rb
+++ b/lib/buildkite/test_collector/rspec_plugin/trace.rb
@@ -8,7 +8,7 @@ module Buildkite::TestCollector::RSpecPlugin
     FILE_PATH_REGEX = /^(.*?\.(rb|feature))/
 
     def initialize(example, history:, failure_reason: nil, failure_expanded: [])
-      @id = Buildkite::TestCollector::Uuid.call
+      @id = Buildkite::TestCollector::UUID.call
       @example = example
       @history = history
       @failure_reason = failure_reason

--- a/lib/buildkite/test_collector/rspec_plugin/trace.rb
+++ b/lib/buildkite/test_collector/rspec_plugin/trace.rb
@@ -8,7 +8,7 @@ module Buildkite::TestCollector::RSpecPlugin
     FILE_PATH_REGEX = /^(.*?\.(rb|feature))/
 
     def initialize(example, history:, failure_reason: nil, failure_expanded: [])
-      @id = SecureRandom.uuid
+      @id = Buildkite::TestCollector::Uuid.call
       @example = example
       @history = history
       @failure_reason = failure_reason

--- a/lib/buildkite/test_collector/uuid.rb
+++ b/lib/buildkite/test_collector/uuid.rb
@@ -2,7 +2,7 @@
 
 require "securerandom"
 
-class Buildkite::TestCollector::Uuid
+class Buildkite::TestCollector::UUID
   GET_UUID = SecureRandom.method(:uuid)
   private_constant :GET_UUID
 

--- a/lib/buildkite/test_collector/uuid.rb
+++ b/lib/buildkite/test_collector/uuid.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+class Buildkite::TestCollector::Uuid
+  GET_UUID = SecureRandom.method(:uuid)
+  private_constant :GET_UUID
+
+  def self.call
+    GET_UUID.call
+  end
+end

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Buildkite::TestCollector::CI do
   describe ".env" do
     let(:ci) { "true" }
-    let(:key) { Buildkite::TestCollector::Uuid.call }
+    let(:key) { Buildkite::TestCollector::UUID.call }
     let(:url) { "http://example.com" }
     let(:branch) { "not-main" }
     let(:sha) { "a2c5ef54" }

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Buildkite::TestCollector::CI do
   describe ".env" do
     let(:ci) { "true" }
-    let(:key) { SecureRandom.uuid }
+    let(:key) { Buildkite::TestCollector::Uuid.call }
     let(:url) { "http://example.com" }
     let(:branch) { "not-main" }
     let(:sha) { "a2c5ef54" }

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe Buildkite::TestCollector::CI do
       before do
         fake_env("CI", ci)
 
-        allow(SecureRandom).to receive(:uuid) { "845ac829-2ab3-4bbb-9e24-3529755a6d37" }
+        allow(Buildkite::TestCollector::UUID).to receive(:call) { "845ac829-2ab3-4bbb-9e24-3529755a6d37" }
       end
 
       it "returns all env" do
@@ -287,7 +287,7 @@ RSpec.describe Buildkite::TestCollector::CI do
 
     context "when not running on a CI platform" do
       before do
-        allow(SecureRandom).to receive(:uuid) { "845ac829-2ab3-4bbb-9e24-3529755a6d37" }
+        allow(Buildkite::TestCollector::UUID).to receive(:call) { "845ac829-2ab3-4bbb-9e24-3529755a6d37" }
       end
 
       it "returns all env" do

--- a/spec/test_collector/http_client_spec.rb
+++ b/spec/test_collector/http_client_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe Buildkite::TestCollector::HTTPClient do
       },
       "format": "json",
       "data": [{
-        "id": trace.id,
         "scope": "i love to eat pies",
         "name": "mince and cheese",
         "location": "123 Pie St",


### PR DESCRIPTION
Builds upon #189 and #187 

We've decided to stop generating execution IDs client side. However, that wasn't the only place the ruby test collector was using SecureRandom.uuid, so am also still including the patch that @ChrisBr submitted that @blaknite then added to 

Has been integration test against bk/bk

There'll be a follow up PR on bk/bk that also ignores any execution IDs that are sent from test collector clients but this PR can be merged and released independently of that 