### PR TITLE
Log standard error raised during upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ git commit -am "Add Buildkite Test Analytics"
 git push origin add-buildkite-test-analytics
 ```
 
+### VCR
+If your test suites use [VCR](https://github.com/vcr/vcr) to interact with HTTP, you need to allow them to make an actual request to Test Analytics.
+
+```
+VCR.configure do |c|
+  c.ignore_hosts "analytics-api.buildkite.com"
+end
+```
+
 ## 🗨️ Annotations
 
 This gem allows adding custom annotations to the span data sent to Buildkite using the [.annotate](https://github.com/buildkite/test-collector-ruby/blob/d9fe11341e4aa470e766febee38124b644572360/lib/buildkite/test_collector.rb#L64) method. For example:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ git push origin add-buildkite-test-analytics
 ```
 
 ### VCR
-If your test suites use [VCR](https://github.com/vcr/vcr) to interact with HTTP, you need to allow them to make an actual request to Test Analytics.
+If your test suites use [VCR](https://github.com/vcr/vcr) to stub network requests, you'll need to modify the config to allow actual network requests to Test Analytics.
 
 ```
 VCR.configure do |c|

--- a/lib/buildkite/test_collector/uploader.rb
+++ b/lib/buildkite/test_collector/uploader.rb
@@ -46,8 +46,8 @@ module Buildkite::TestCollector
             retry
           end
         rescue StandardError => e
-          $stderr.puts "#{Buildkite::TestCollector::NAME} #{Buildkite::TestCollector::VERSION} experienced an error when sending your data, you may be missing some executions for this run."
           $stderr.puts e
+          $stderr.puts "#{Buildkite::TestCollector::NAME} #{Buildkite::TestCollector::VERSION} experienced an error when sending your data, you may be missing some executions for this run."
         end
       end
     end

--- a/lib/buildkite/test_collector/uploader.rb
+++ b/lib/buildkite/test_collector/uploader.rb
@@ -47,6 +47,7 @@ module Buildkite::TestCollector
           end
         rescue StandardError => e
           $stderr.puts "#{Buildkite::TestCollector::NAME} #{Buildkite::TestCollector::VERSION} experienced an error when sending your data, you may be missing some executions for this run."
+          $stderr.puts e
         end
       end
     end


### PR DESCRIPTION
We rescue a standard error during upload to prevent builds from failing. However, there is no way to know what the real errors are. We want to log the error while silently rescuing it so we know what went wrong.

This fixes issue https://github.com/buildkite/test-collector-ruby/issues/194

I also updated the documentation for an extra step when using VCR in a test suites, as raised by that same issue.

