### PR TITLE
Bump version to v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v2.3.1
+- Log standard error raised during upload #195 - @nprizal
+
 ## v2.3.0
 - Stop sending execution id and safeguard SecureRandom.uuid #192 - @niceking
 - Rescue from StandardError when sending upload request #191 - @niceking

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    buildkite-test_collector (2.3.0)
+    buildkite-test_collector (2.3.1)
       activesupport (>= 4.2)
 
 GEM

--- a/lib/buildkite/test_collector/version.rb
+++ b/lib/buildkite/test_collector/version.rb
@@ -2,7 +2,7 @@
 
 module Buildkite
   module TestCollector
-    VERSION = "2.3.0"
+    VERSION = "2.3.1"
     NAME = "buildkite-test_collector"
   end
 end


### PR DESCRIPTION
What's changed:

- [Log standard error raised during upload](https://github.com/buildkite/test-collector-ruby/pull/195)