### PR TITLE
[PIE-1834] Add build_id and build_number to collector

### DIFF
--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -82,8 +82,8 @@ class Buildkite::TestCollector::CI
       "url" => ENV["CIRCLE_BUILD_URL"],
       "branch" => ENV["CIRCLE_BRANCH"],
       "commit_sha" => ENV["CIRCLE_SHA1"],
-      "number" => ENV["CIRCLE_WORKFLOW_ID"],
-      "build_id" => "#{ENV["CIRCLE_WORKFLOW_WORKSPACE_ID"]}-#{ENV["CIRCLE_WORKFLOW_ID"]}"
+      "number" => ENV["CIRCLE_WORKFLOW_ID"], # There is no human readable ENV in CircleCi
+      "build_id" => ENV["CIRCLE_WORKFLOW_ID"] # Retries in CircleCi generate a new workflow id each time
     }
   end
 end

--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -16,7 +16,7 @@ class Buildkite::TestCollector::CI
   def ci_env
     return buildkite if ENV["BUILDKITE_BUILD_ID"]
     return github_actions if ENV["GITHUB_RUN_NUMBER"]
-    return circleci if ENV["CIRCLE_BUILD_NUM"]
+    return circleci if ENV["CIRCLE_WORKFLOW_ID"]
     return generic if ENV["CI"]
 
     {
@@ -82,8 +82,8 @@ class Buildkite::TestCollector::CI
       "url" => ENV["CIRCLE_BUILD_URL"],
       "branch" => ENV["CIRCLE_BRANCH"],
       "commit_sha" => ENV["CIRCLE_SHA1"],
-      "number" => ENV["CIRCLE_BUILD_NUM"],
-      "build_id" => ENV["CIRCLE_WORKFLOW_ID"]
+      "number" => ENV["CIRCLE_WORKFLOW_ID"],
+      "build_id" => "#{ENV["CIRCLE_WORKFLOW_WORKSPACE_ID"]}-#{ENV["CIRCLE_WORKFLOW_ID"]}"
     }
   end
 end

--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -38,6 +38,8 @@ class Buildkite::TestCollector::CI
       "execution_name_suffix" => ENV["BUILDKITE_ANALYTICS_EXECUTION_NAME_SUFFIX"],
       "version" => Buildkite::TestCollector::VERSION,
       "collector" => "ruby-#{Buildkite::TestCollector::NAME}",
+      "build_number" => ENV["BUILDKITE_BUILD_NUMBER"],
+      "build_id" => ENV["BUILDKITE_BUILD_ID"]
     }.compact
   end
 
@@ -58,6 +60,8 @@ class Buildkite::TestCollector::CI
       "number" => ENV["BUILDKITE_BUILD_NUMBER"],
       "job_id" => ENV["BUILDKITE_JOB_ID"],
       "message" => ENV["BUILDKITE_MESSAGE"],
+      "build_number" => ENV["BUILDKITE_BUILD_NUMBER"],
+      "build_id" => ENV["BUILDKITE_BUILD_ID"]
     }
   end
 
@@ -69,6 +73,8 @@ class Buildkite::TestCollector::CI
       "branch" => ENV["GITHUB_REF_NAME"],
       "commit_sha" => ENV["GITHUB_SHA"],
       "number" => ENV["GITHUB_RUN_NUMBER"],
+      "build_number" => ENV["GITHUB_RUN_NUMBER"],
+      "build_id" => ENV["GITHUB_RUN_ID"]
     }
   end
 
@@ -80,6 +86,8 @@ class Buildkite::TestCollector::CI
       "branch" => ENV["CIRCLE_BRANCH"],
       "commit_sha" => ENV["CIRCLE_SHA1"],
       "number" => ENV["CIRCLE_BUILD_NUM"],
+      "build_number" => ENV["CIRCLE_BUILD_NUM"],
+      "build_id" => ENV["CIRCLE_WORKFLOW_ID"]
     }
   end
 end

--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -37,8 +37,8 @@ class Buildkite::TestCollector::CI
       "execution_name_suffix" => ENV["BUILDKITE_ANALYTICS_EXECUTION_NAME_SUFFIX"],
       "version" => Buildkite::TestCollector::VERSION,
       "collector" => "ruby-#{Buildkite::TestCollector::NAME}",
-      "build_number" => ENV["BUILDKITE_ANALYTICS_NUMBER"],
-      "build_id" => ENV["BUILDKITE_BUILD_ID"]
+      "number" => ENV["BUILDKITE_ANALYTICS_NUMBER"],
+      "build_id" => ENV["BUILDKITE_ANALYTICS_BUILD_ID"]
     }.compact
   end
 
@@ -58,7 +58,7 @@ class Buildkite::TestCollector::CI
       "commit_sha" => ENV["BUILDKITE_COMMIT"],
       "job_id" => ENV["BUILDKITE_JOB_ID"],
       "message" => ENV["BUILDKITE_MESSAGE"],
-      "build_number" => ENV["BUILDKITE_BUILD_NUMBER"],
+      "number" => ENV["BUILDKITE_BUILD_NUMBER"],
       "build_id" => ENV["BUILDKITE_BUILD_ID"]
     }
   end
@@ -70,19 +70,19 @@ class Buildkite::TestCollector::CI
       "url" => File.join("https://github.com", ENV["GITHUB_REPOSITORY"], "actions/runs", ENV["GITHUB_RUN_ID"]),
       "branch" => ENV["GITHUB_REF_NAME"],
       "commit_sha" => ENV["GITHUB_SHA"],
-      "build_number" => ENV["GITHUB_RUN_NUMBER"],
-      "build_id" => ENV["GITHUB_RUN_ID"]
+      "number" => ENV["GITHUB_RUN_NUMBER"],
+      "build_id" => "#{ENV["GITHUB_RUN_ID"]}-#{ENV["GITHUB_RUN_ATTEMPT"]}"
     }
   end
 
   def circleci
     {
       "CI" => "circleci",
-      "key" => "#{ENV["CIRCLE_WORKFLOW_ID"]}-#{ENV["CIRCLE_BUILD_NUM"]}",
+      "key" => ENV["CIRCLE_WORKFLOW_ID"],
       "url" => ENV["CIRCLE_BUILD_URL"],
       "branch" => ENV["CIRCLE_BRANCH"],
       "commit_sha" => ENV["CIRCLE_SHA1"],
-      "build_number" => ENV["CIRCLE_BUILD_NUM"],
+      "number" => ENV["CIRCLE_BUILD_NUM"],
       "build_id" => ENV["CIRCLE_WORKFLOW_ID"]
     }
   end

--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -31,14 +31,13 @@ class Buildkite::TestCollector::CI
       "url" => ENV["BUILDKITE_ANALYTICS_URL"],
       "branch" => ENV["BUILDKITE_ANALYTICS_BRANCH"],
       "commit_sha" => ENV["BUILDKITE_ANALYTICS_SHA"],
-      "number" => ENV["BUILDKITE_ANALYTICS_NUMBER"],
       "job_id" => ENV["BUILDKITE_ANALYTICS_JOB_ID"],
       "message" => ENV["BUILDKITE_ANALYTICS_MESSAGE"],
       "execution_name_prefix" => ENV["BUILDKITE_ANALYTICS_EXECUTION_NAME_PREFIX"],
       "execution_name_suffix" => ENV["BUILDKITE_ANALYTICS_EXECUTION_NAME_SUFFIX"],
       "version" => Buildkite::TestCollector::VERSION,
       "collector" => "ruby-#{Buildkite::TestCollector::NAME}",
-      "build_number" => ENV["BUILDKITE_BUILD_NUMBER"],
+      "build_number" => ENV["BUILDKITE_ANALYTICS_NUMBER"],
       "build_id" => ENV["BUILDKITE_BUILD_ID"]
     }.compact
   end
@@ -57,7 +56,6 @@ class Buildkite::TestCollector::CI
       "url" => ENV["BUILDKITE_BUILD_URL"],
       "branch" => ENV["BUILDKITE_BRANCH"],
       "commit_sha" => ENV["BUILDKITE_COMMIT"],
-      "number" => ENV["BUILDKITE_BUILD_NUMBER"],
       "job_id" => ENV["BUILDKITE_JOB_ID"],
       "message" => ENV["BUILDKITE_MESSAGE"],
       "build_number" => ENV["BUILDKITE_BUILD_NUMBER"],
@@ -72,7 +70,6 @@ class Buildkite::TestCollector::CI
       "url" => File.join("https://github.com", ENV["GITHUB_REPOSITORY"], "actions/runs", ENV["GITHUB_RUN_ID"]),
       "branch" => ENV["GITHUB_REF_NAME"],
       "commit_sha" => ENV["GITHUB_SHA"],
-      "number" => ENV["GITHUB_RUN_NUMBER"],
       "build_number" => ENV["GITHUB_RUN_NUMBER"],
       "build_id" => ENV["GITHUB_RUN_ID"]
     }
@@ -85,7 +82,6 @@ class Buildkite::TestCollector::CI
       "url" => ENV["CIRCLE_BUILD_URL"],
       "branch" => ENV["CIRCLE_BRANCH"],
       "commit_sha" => ENV["CIRCLE_SHA1"],
-      "number" => ENV["CIRCLE_BUILD_NUM"],
       "build_number" => ENV["CIRCLE_BUILD_NUM"],
       "build_id" => ENV["CIRCLE_WORKFLOW_ID"]
     }

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -61,12 +61,13 @@ RSpec.describe Buildkite::TestCollector::CI do
           "url" => bk_build_url,
           "branch" => bk_branch,
           "commit_sha" => bk_sha,
-          "number" => bk_number,
           "job_id" => bk_job_id,
           "message" => bk_message,
           "version" => version,
           "collector" => name,
           "test" => test_value,
+          "build_number" => bk_number,
+          "build_id" => bk_build_uuid
         })
       end
 
@@ -92,7 +93,6 @@ RSpec.describe Buildkite::TestCollector::CI do
             "url" => url,
             "branch" => branch,
             "commit_sha" => sha,
-            "number" => number,
             "job_id" => job_id,
             "message" => message,
             "execution_name_prefix" => "execution_name_prefix",
@@ -100,6 +100,8 @@ RSpec.describe Buildkite::TestCollector::CI do
             "version" => version,
             "collector" => name,
             "test" => test_value,
+            "build_number" => number,
+            "build_id" => bk_build_uuid
           })
         end
       end
@@ -131,13 +133,14 @@ RSpec.describe Buildkite::TestCollector::CI do
         expect(result).to match({
           "CI" => "github_actions",
           "key" => "some_action-4242-1",
-          "url" => "https://github.com/rofl/lol/actions/runs/2424",
+          "url" => "https://github.com/rofl/lol/actions/runs/#{gha_run_id}",
           "branch" => gha_ref,
           "commit_sha" => gha_sha,
-          "number" => gha_run_number,
           "version" => version,
           "collector" => name,
           "test" => test_value,
+          "build_number" => gha_run_number,
+          "build_id" => gha_run_id
         })
       end
 
@@ -161,12 +164,13 @@ RSpec.describe Buildkite::TestCollector::CI do
             "url" => url,
             "branch" => branch,
             "commit_sha" => sha,
-            "number" => number,
             "job_id" => job_id,
             "message" => message,
             "version" => version,
             "collector" => name,
             "test" => test_value,
+            "build_number" => number,
+            "build_id" => gha_run_id
           })
         end
       end
@@ -193,14 +197,15 @@ RSpec.describe Buildkite::TestCollector::CI do
 
         expect(result).to match({
           "CI" => "circleci",
-          "key" => "4242-2424",
+          "key" => "#{c_workflow_id}-#{c_number}",
           "url" => c_url,
           "branch" => c_branch,
           "commit_sha" => c_sha,
-          "number" => c_number,
           "version" => version,
           "collector" => name,
           "test" => test_value,
+          "build_number" => c_number,
+          "build_id" => c_workflow_id
         })
       end
 
@@ -224,12 +229,13 @@ RSpec.describe Buildkite::TestCollector::CI do
             "url" => url,
             "branch" => branch,
             "commit_sha" => sha,
-            "number" => number,
             "job_id" => job_id,
             "message" => message,
             "version" => version,
             "collector" => name,
             "test" => test_value,
+            "build_number" => number,
+            "build_id" => c_workflow_id
           })
         end
       end
@@ -274,12 +280,12 @@ RSpec.describe Buildkite::TestCollector::CI do
             "url" => url,
             "branch" => branch,
             "commit_sha" => sha,
-            "number" => number,
             "job_id" => job_id,
             "message" => message,
             "version" => version,
             "collector" => name,
             "test" => test_value,
+            "build_number" => number,
           })
         end
       end
@@ -322,12 +328,12 @@ RSpec.describe Buildkite::TestCollector::CI do
             "url" => url,
             "branch" => branch,
             "commit_sha" => sha,
-            "number" => number,
             "job_id" => job_id,
             "message" => message,
             "version" => version,
             "collector" => name,
             "test" => test_value,
+            "build_number" => number,
           })
         end
       end

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Buildkite::TestCollector::CI do
           "version" => version,
           "collector" => name,
           "test" => test_value,
-          "build_number" => bk_number,
+          "number" => bk_number,
           "build_id" => bk_build_uuid
         })
       end
@@ -100,7 +100,7 @@ RSpec.describe Buildkite::TestCollector::CI do
             "version" => version,
             "collector" => name,
             "test" => test_value,
-            "build_number" => number,
+            "number" => number,
             "build_id" => bk_build_uuid
           })
         end
@@ -139,8 +139,8 @@ RSpec.describe Buildkite::TestCollector::CI do
           "version" => version,
           "collector" => name,
           "test" => test_value,
-          "build_number" => gha_run_number,
-          "build_id" => gha_run_id
+          "number" => gha_run_number,
+          "build_id" => "#{gha_run_id}-#{gha_run_attempt}"
         })
       end
 
@@ -169,8 +169,8 @@ RSpec.describe Buildkite::TestCollector::CI do
             "version" => version,
             "collector" => name,
             "test" => test_value,
-            "build_number" => number,
-            "build_id" => gha_run_id
+            "number" => number,
+            "build_id" => "#{gha_run_id}-#{gha_run_attempt}"
           })
         end
       end
@@ -197,14 +197,14 @@ RSpec.describe Buildkite::TestCollector::CI do
 
         expect(result).to match({
           "CI" => "circleci",
-          "key" => "#{c_workflow_id}-#{c_number}",
+          "key" => c_workflow_id,
           "url" => c_url,
           "branch" => c_branch,
           "commit_sha" => c_sha,
           "version" => version,
           "collector" => name,
           "test" => test_value,
-          "build_number" => c_number,
+          "number" => c_number,
           "build_id" => c_workflow_id
         })
       end
@@ -234,7 +234,7 @@ RSpec.describe Buildkite::TestCollector::CI do
             "version" => version,
             "collector" => name,
             "test" => test_value,
-            "build_number" => number,
+            "number" => number,
             "build_id" => c_workflow_id
           })
         end
@@ -285,7 +285,7 @@ RSpec.describe Buildkite::TestCollector::CI do
             "version" => version,
             "collector" => name,
             "test" => test_value,
-            "build_number" => number,
+            "number" => number,
           })
         end
       end
@@ -333,7 +333,7 @@ RSpec.describe Buildkite::TestCollector::CI do
             "version" => version,
             "collector" => name,
             "test" => test_value,
-            "build_number" => number,
+            "number" => number,
           })
         end
       end

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -178,7 +178,6 @@ RSpec.describe Buildkite::TestCollector::CI do
 
     context "when running on CircleCI" do
       let(:c_workflow_id) { "4242" }
-      let(:c_workflow_workspace_id) { "1234" }
       let(:c_number) { "2424" }
       let(:c_url) { "http://example.com/circle" }
       let(:c_branch) { "main" }
@@ -190,7 +189,6 @@ RSpec.describe Buildkite::TestCollector::CI do
         fake_env("CIRCLE_BUILD_URL", c_url)
         fake_env("CIRCLE_BRANCH", c_branch)
         fake_env("CIRCLE_SHA1", c_sha)
-        fake_env("CIRCLE_WORKFLOW_WORKSPACE_ID", c_workflow_workspace_id)
       end
 
       it "returns all env" do
@@ -206,7 +204,7 @@ RSpec.describe Buildkite::TestCollector::CI do
           "collector" => name,
           "test" => test_value,
           "number" => c_workflow_id,
-          "build_id" => "#{c_workflow_workspace_id}-#{c_workflow_id}"
+          "build_id" => c_workflow_id
         })
       end
 
@@ -236,7 +234,7 @@ RSpec.describe Buildkite::TestCollector::CI do
             "collector" => name,
             "test" => test_value,
             "number" => number,
-            "build_id" => "#{c_workflow_workspace_id}-#{c_workflow_id}"
+            "build_id" => c_workflow_id
           })
         end
       end

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -178,6 +178,7 @@ RSpec.describe Buildkite::TestCollector::CI do
 
     context "when running on CircleCI" do
       let(:c_workflow_id) { "4242" }
+      let(:c_workflow_workspace_id) { "1234" }
       let(:c_number) { "2424" }
       let(:c_url) { "http://example.com/circle" }
       let(:c_branch) { "main" }
@@ -186,10 +187,10 @@ RSpec.describe Buildkite::TestCollector::CI do
       before do
         fake_env("CI", ci)
         fake_env("CIRCLE_WORKFLOW_ID", c_workflow_id)
-        fake_env("CIRCLE_BUILD_NUM", c_number)
         fake_env("CIRCLE_BUILD_URL", c_url)
         fake_env("CIRCLE_BRANCH", c_branch)
         fake_env("CIRCLE_SHA1", c_sha)
+        fake_env("CIRCLE_WORKFLOW_WORKSPACE_ID", c_workflow_workspace_id)
       end
 
       it "returns all env" do
@@ -204,8 +205,8 @@ RSpec.describe Buildkite::TestCollector::CI do
           "version" => version,
           "collector" => name,
           "test" => test_value,
-          "number" => c_number,
-          "build_id" => c_workflow_id
+          "number" => c_workflow_id,
+          "build_id" => "#{c_workflow_workspace_id}-#{c_workflow_id}"
         })
       end
 
@@ -235,7 +236,7 @@ RSpec.describe Buildkite::TestCollector::CI do
             "collector" => name,
             "test" => test_value,
             "number" => number,
-            "build_id" => c_workflow_id
+            "build_id" => "#{c_workflow_workspace_id}-#{c_workflow_id}"
           })
         end
       end


### PR DESCRIPTION
## Description
As part of the flexi-test-grouping work, new env vars are required to create the new build views in TA. We noted that vars from other ci providers do not directly map to Buildkites, so some tweaks have been made to the github and circleci `:env`.
As these run_env variables are internal to the collector and the required ENV VARs are being passed already, there is no required update to the ruby collector docs.

Bump to version will occur in future PR.

## Context
[PIE-1834](https://linear.app/buildkite/issue/PIE-1834/patch-test-collector-ruby-to-send-new-env-attributes)

## Changes
- `build_id` has been added to this test collector
- env vars for github and circleci have been updated to ensure build_ids remain unique upon run retries.

## Deployment / Risk
Low risk
