### PR TITLE
Test gem under every supported Ruby version

### DIFF
--- a/buildkite.yaml
+++ b/buildkite.yaml
@@ -7,6 +7,7 @@ steps:
       - docker#v3.7.0:
           image: "445615400570.dkr.ecr.us-east-1.amazonaws.com/ecr-public/docker/library/ruby:{{matrix}}"
     matrix:
+      - "latest"
       - "3.2.2"
       - "3.1.4"
       - "3.0.6"

--- a/buildkite.yaml
+++ b/buildkite.yaml
@@ -8,10 +8,10 @@ steps:
           image: "445615400570.dkr.ecr.us-east-1.amazonaws.com/ecr-public/docker/library/ruby:{{matrix}}"
     matrix:
       - "latest"
-      - "3.2.2"
-      - "3.1.4"
-      - "3.0.6"
-      - "2.7.8"
+      - "3.2"
+      - "3.1"
+      - "3.0"
+      - "2.7"
   - group: ":rspec: Legacy Ruby :ruby:"
     steps:
       - label: ":rspec: Tests :ruby: {{matrix}}"
@@ -26,7 +26,7 @@ steps:
               # so fall back to Docker Hub
               image: "ruby:{{matrix}}"
         matrix:
-          - "2.6.10"
-          - "2.5.9"
-          - "2.4.10"
-          - "2.3.8"
+          - "2.6"
+          - "2.5"
+          - "2.4"
+          - "2.3"

--- a/buildkite.yaml
+++ b/buildkite.yaml
@@ -1,8 +1,31 @@
 steps:
-  - label: ":rspec: Tests"
+  - label: ":rspec: Tests :ruby: {{matrix}}"
     command:
       - "bundle"
       - "bundle exec rake"
     plugins:
       - docker#v3.7.0:
-          image: 445615400570.dkr.ecr.us-east-1.amazonaws.com/ecr-public/docker/library/ruby:3.1.4
+          image: "445615400570.dkr.ecr.us-east-1.amazonaws.com/ecr-public/docker/library/ruby:{{matrix}}"
+    matrix:
+      - "3.2.2"
+      - "3.1.4"
+      - "3.0.6"
+      - "2.7.8"
+  - group: ":rspec: Legacy Ruby :ruby:"
+    steps:
+      - label: ":rspec: Tests :ruby: {{matrix}}"
+        command:
+          - "gem install bundler:2.3.25"
+          - "bundle"
+          - "bundle exec rake"
+        soft_fail: true
+        plugins:
+          - docker#v3.7.0:
+              # Images for older Ruby versions aren't available on AWS ECR
+              # so fall back to Docker Hub
+              image: "ruby:{{matrix}}"
+        matrix:
+          - "2.6.10"
+          - "2.5.9"
+          - "2.4.10"
+          - "2.3.8"


### PR DESCRIPTION
Update build pipeline to run tests under multiple Ruby versions

All minor Ruby versions from 3.2 to 2.3 will be tested.

The gemspec says Ruby versions from 2.3.x are supported, however
some modern Ruby syntax was introduced which breaks compatibility
for older Ruby versions.

