### PR TITLE
Restore compatibility with older Ruby versions

### DIFF
--- a/buildkite.yaml
+++ b/buildkite.yaml
@@ -19,7 +19,6 @@ steps:
           - "gem install bundler:2.3.25"
           - "bundle"
           - "bundle exec rake"
-        soft_fail: true
         plugins:
           - docker#v3.7.0:
               # Images for older Ruby versions aren't available on AWS ECR

--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -39,7 +39,7 @@ class Buildkite::TestCollector::CI
       "execution_name_suffix" => ENV["BUILDKITE_ANALYTICS_EXECUTION_NAME_SUFFIX"],
       "version" => Buildkite::TestCollector::VERSION,
       "collector" => "ruby-#{Buildkite::TestCollector::NAME}",
-    }.compact
+    }.select { |_, value| !value.nil? }
   end
 
   def generic

--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -74,7 +74,7 @@ module Buildkite::TestCollector::MinitestPlugin
         # remove the first line of message from the first failure
         # to avoid duplicate line in Test Analytics UI
         messages = strip_invalid_utf8_chars(failure.message).split("\n")
-        messages = messages[1..] if index.zero?
+        messages = messages[1..-1] if index.zero?
 
         {
           expanded: messages,

--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -50,7 +50,7 @@ module Buildkite::TestCollector::MinitestPlugin
     end
 
     def file_name
-      @file_name ||= File.join('./', source_location[0].delete_prefix(project_dir))
+      @file_name ||= File.join('./', source_location[0].sub(/\A#{project_dir}/, ""))
     end
 
     def line_number

--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -38,7 +38,7 @@ module Buildkite::TestCollector::MinitestPlugin
         failure_reason: failure_reason,
         failure_expanded: failure_expanded,
         history: history,
-      ).with_indifferent_access.compact
+      ).with_indifferent_access.select { |_, value| !value.nil? }
     end
 
     private

--- a/lib/buildkite/test_collector/rspec_plugin/trace.rb
+++ b/lib/buildkite/test_collector/rspec_plugin/trace.rb
@@ -32,7 +32,7 @@ module Buildkite::TestCollector::RSpecPlugin
         failure_reason: failure_reason,
         failure_expanded: failure_expanded,
         history: history,
-      ).with_indifferent_access.compact
+      ).with_indifferent_access.select { |_, value| !value.nil? }
     end
 
     private


### PR DESCRIPTION
The gemspec file states Ruby versions 2.3 and above is supported but there is code which breaks compatibility with versions 2.3, 2.4 and 2.5.

See https://github.com/buildkite/test-collector-ruby/issues/199

This PR removes the use Ruby features/syntax that were introduced in 2.4, 2.5 and 2.6.
