### PR TITLE
Test collector on 3.3-rc Ruby in anticipation of Dec 2023 release

### DIFF
--- a/buildkite.yaml
+++ b/buildkite.yaml
@@ -1,4 +1,13 @@
 steps:
+  - label: ":rspec: Tests :ruby: 3.3-rc"
+    command:
+      - "bundle"
+      - "bundle exec rake"
+    plugins:
+      - docker#v3.7.0:
+          image: "445615400570.dkr.ecr.us-east-1.amazonaws.com/ecr-public/docker/library/ruby:3.3-rc"
+    soft_fail: true
+
   - label: ":rspec: Tests :ruby: {{matrix}}"
     command:
       - "bundle"
@@ -12,6 +21,7 @@ steps:
       - "3.1"
       - "3.0"
       - "2.7"
+
   - group: ":rspec: Legacy Ruby :ruby:"
     steps:
       - label: ":rspec: Tests :ruby: {{matrix}}"


### PR DESCRIPTION
Test collector on 3.3-rc Ruby in anticipation of Dec 2023 release

Failures on 3.3-rc will not fail the build.