### PR TITLE
Prepare gem for 2.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,31 @@
 # CHANGELOG
 
+## v2.3.2
+
+- Add support for Codeship #198 - @swebb
+- Restore compatibility with older Ruby versions #201 - @gchan
+- Report Ruby version to Test Analytics #203 - @gchan
+
 ## v2.3.1
+
 - Log standard error raised during upload #195 - @nprizal
 
 ## v2.3.0
+
 - Stop sending execution id and safeguard SecureRandom.uuid #192 - @niceking
 - Rescue from StandardError when sending upload request #191 - @niceking
 - Fix nil pointer #188 - @ChrisBr
 
 ## v2.2.0
+
 - Gzip payload of request to Upload API #183 - @niceking
 
 ## v2.1.0
+
 - Major change: deprecates websocket connection in favour of sending HTTP requests to the Upload API. In future, websocket support will be completely removed from Buildkite and only version 2.1+ of this gem will continue to work.
 
 ## v2.1.0.pre
+
 - Minitest plugin to use HTTP Upload API instead of websocket connection to send test data #178 #179 - @niceking
 
 ## v2.0.0.pre
@@ -32,6 +43,7 @@
 - Update collector argument in the Analytics::API payload #170 - @KatieWright26
 
 ## v1.4.1
+
 - Add in support to create file with trace data #167
 
 ## v1.3.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,22 @@
 PATH
   remote: .
   specs:
-    buildkite-test_collector (2.3.1)
+    buildkite-test_collector (2.3.2)
       activesupport (>= 4.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4.3)
+    activesupport (7.0.7.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     concurrent-ruby (1.2.2)
     diff-lcs (1.4.4)
-    i18n (1.13.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    minitest (5.18.0)
+    minitest (5.19.0)
     rake (13.0.6)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)

--- a/lib/buildkite/test_collector/version.rb
+++ b/lib/buildkite/test_collector/version.rb
@@ -2,7 +2,7 @@
 
 module Buildkite
   module TestCollector
-    VERSION = "2.3.1"
+    VERSION = "2.3.2"
     NAME = "buildkite-test_collector"
   end
 end


### PR DESCRIPTION
Relevant changes 

- Add support for Codeship #198 - @swebb
- Restore compatibility with older Ruby versions #201 - @gchan
- Report Ruby version to Test Analytics #203 - @gchan