### PR TITLE
PIE-1986 ensure all traces are added to the trace list

### DIFF
--- a/lib/buildkite/test_collector/library_hooks/rspec.rb
+++ b/lib/buildkite/test_collector/library_hooks/rspec.rb
@@ -20,6 +20,9 @@ RSpec.configure do |config|
     # as we are in the main thread
     Thread.current[:_buildkite_tracer] = tracer
     example.run
+  # example.run can raise an exception when there is another around hook that raises an exception.
+  # We need to ensure that we always clean up the resource and add the trace to the traces
+  ensure
     Thread.current[:_buildkite_tracer] = nil
 
     tracer.finalize


### PR DESCRIPTION
### Description
We found that some failed tests are in Rspec not being reported to test analytics, due to another `around` hook throws an exception after running the test. This PR ensure all test traces are added to the list, so it can be reported to Test Analytics.