### PR TITLE
Bump version to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.4.0
+
+- Feature release: Output links to Test Analytic tests within the rspec log @meghan-kradolfer
+
 ## v2.3.2
 
 - Add support for Codeship #198 - @swebb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,27 +7,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.2)
-      base64
-      bigdecimal
+    activesupport (7.0.7.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      connection_pool (>= 2.2.5)
-      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
-      mutex_m
       tzinfo (~> 2.0)
-    base64 (0.2.0)
-    bigdecimal (3.1.4)
     concurrent-ruby (1.2.2)
-    connection_pool (2.4.1)
     diff-lcs (1.4.4)
-    drb (2.2.0)
-      ruby2_keywords
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    minitest (5.20.0)
-    mutex_m (0.2.0)
+    minitest (5.19.0)
     rake (13.0.6)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -42,7 +31,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.3)
-    ruby2_keywords (0.0.5)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,33 @@
 PATH
   remote: .
   specs:
-    buildkite-test_collector (2.3.2)
+    buildkite-test_collector (2.4.0)
       activesupport (>= 4.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.7.2)
+    activesupport (7.1.1)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.4)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     diff-lcs (1.4.4)
+    drb (2.2.0)
+      ruby2_keywords
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    minitest (5.19.0)
+    minitest (5.20.0)
+    mutex_m (0.2.0)
     rake (13.0.6)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -31,6 +42,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.3)
+    ruby2_keywords (0.0.5)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.1)
+    activesupport (7.1.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)

--- a/lib/buildkite/test_collector/version.rb
+++ b/lib/buildkite/test_collector/version.rb
@@ -2,7 +2,7 @@
 
 module Buildkite
   module TestCollector
-    VERSION = "2.3.2"
+    VERSION = "2.4.0"
     NAME = "buildkite-test_collector"
   end
 end


### PR DESCRIPTION
What's changed:

- [Output a summary of TA links in rspec log](https://github.com/buildkite/test-collector-ruby/pull/207) 
- [Add signifier to link outputs](https://github.com/buildkite/test-collector-ruby/pull/209)