### PR TITLE
WIP: upload direct to TA storage via URL from uploads/prepare API

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "rspec/buildkite/analytics"
+require "buildkite/test_collector"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -41,6 +41,12 @@ module Buildkite
       attr_accessor :artifact_path
       attr_accessor :env
       attr_accessor :batch_size
+
+      def upload_prepare_url
+        return nil unless url # prior to .configure
+
+        "#{url}/prepare"
+      end
     end
 
     def self.configure(hook:, token: nil, url: nil, tracing_enabled: true, artifact_path: nil, env: {})


### PR DESCRIPTION
_Work in progress_

Two-step upload via `/v1/uploads/prepare` endpoint (which does not yet exist), allowing the server to provide dynamic upload instructions. This allows more efficient uploads directly from the collector to a storage/ingestion backend.