### PR TITLE
Remove ActiveSupport from being a primary dependency.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     buildkite-test_collector (2.4.0)
-      activesupport (>= 4.2)
 
 GEM
   remote: https://rubygems.org/
@@ -38,6 +37,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (>= 4.2)
   buildkite-test_collector!
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/buildkite-test_collector.gemspec
+++ b/buildkite-test_collector.gemspec
@@ -24,8 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
-  spec.add_dependency "activesupport", ">= 4.2"
-
+  spec.add_development_dependency "activesupport", ">= 4.2"
   spec.add_development_dependency "rspec-core", '~> 3.10'
   spec.add_development_dependency "rspec-expectations", '~> 3.10'
 end

--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -12,7 +12,6 @@ require "time"
 require "timeout"
 require "tmpdir"
 
-require "active_support/core_ext/object/blank"
 require "active_support/core_ext/hash/indifferent_access"
 require "active_support/notifications"
 

--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -8,6 +8,7 @@ end
 require "json"
 require "logger"
 require "net/http"
+require "openssl"
 require "time"
 require "timeout"
 require "tmpdir"

--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -12,8 +12,6 @@ require "time"
 require "timeout"
 require "tmpdir"
 
-require "active_support/notifications"
-
 require_relative "test_collector/version"
 require_relative "test_collector/error"
 require_relative "test_collector/ci"
@@ -69,6 +67,10 @@ module Buildkite
 
       Buildkite::TestCollector::Network.configure
       Buildkite::TestCollector::Object.configure
+
+      return unless defined?(ActiveSupport)
+
+      require "active_support/notifications"
 
       ActiveSupport::Notifications.subscribe("sql.active_record") do |name, start, finish, id, payload|
         Buildkite::TestCollector::Uploader.tracer&.backfill(:sql, finish - start, **{ query: payload[:sql] })

--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -12,7 +12,6 @@ require "time"
 require "timeout"
 require "tmpdir"
 
-require "active_support/core_ext/hash/indifferent_access"
 require "active_support/notifications"
 
 require_relative "test_collector/version"

--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -38,7 +38,7 @@ module Buildkite::TestCollector::MinitestPlugin
         failure_reason: failure_reason,
         failure_expanded: failure_expanded,
         history: history,
-      ).with_indifferent_access.select { |_, value| !value.nil? }
+      ).select { |_, value| !value.nil? }
     end
 
     private

--- a/lib/buildkite/test_collector/rspec_plugin/reporter.rb
+++ b/lib/buildkite/test_collector/rspec_plugin/reporter.rb
@@ -40,6 +40,10 @@ module Buildkite::TestCollector::RSpecPlugin
       RSpec::Core::MultipleExceptionError
     ]
 
+    def blank?(string)
+      string.nil? || string.strip.empty?
+    end
+
     def failure_info(notification)
       failure_expanded = []
 
@@ -73,9 +77,9 @@ module Buildkite::TestCollector::RSpecPlugin
     def format_message_lines(message_lines)
       message_lines.map! { |l| strip_diff_colors(l) }
       # the first line is sometimes blank, depending on the error reported
-      message_lines.shift if message_lines.first.blank?
+      message_lines.shift if blank?(message_lines.first)
       # the last line is sometimes blank, depending on the error reported
-      message_lines.pop if message_lines.last.blank?
+      message_lines.pop if blank?(message_lines.last)
       message_lines
     end
 

--- a/lib/buildkite/test_collector/rspec_plugin/trace.rb
+++ b/lib/buildkite/test_collector/rspec_plugin/trace.rb
@@ -32,7 +32,7 @@ module Buildkite::TestCollector::RSpecPlugin
         failure_reason: failure_reason,
         failure_expanded: failure_expanded,
         history: history,
-      ).with_indifferent_access.select { |_, value| !value.nil? }
+      ).select { |_, value| !value.nil? }
     end
 
     private

--- a/lib/buildkite/test_collector/rspec_plugin/trace.rb
+++ b/lib/buildkite/test_collector/rspec_plugin/trace.rb
@@ -60,7 +60,7 @@ module Buildkite::TestCollector::RSpecPlugin
     end
 
     def shared_example?
-      example.metadata[:shared_group_inclusion_backtrace].any?
+      !example.metadata[:shared_group_inclusion_backtrace].empty?
     end
 
     def shared_example_call_location

--- a/lib/buildkite/test_collector/test_links_plugin/formatter.rb
+++ b/lib/buildkite/test_collector/test_links_plugin/formatter.rb
@@ -10,7 +10,7 @@ module Buildkite::TestCollector::TestLinksPlugin
 
     def dump_failures(notification)
       # Do not display summary if no failed examples
-      return unless notification.failed_examples.present?
+      return if notification.failed_examples.empty?
 
       # Check if a Test Analytics token is set
       return unless Buildkite::TestCollector.api_token

--- a/lib/buildkite/test_collector/tracer.rb
+++ b/lib/buildkite/test_collector/tracer.rb
@@ -43,7 +43,7 @@ module Buildkite::TestCollector
           duration: end_at - start_at,
           detail: detail,
           children: children.map(&:as_hash),
-        }.with_indifferent_access
+        }
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "buildkite/test_collector"
+require "active_support/notifications"
 
 Dir["spec/support/**/*.rb"].each { |f| require File.expand_path(f) }
 


### PR DESCRIPTION
Hi fine Bikkies 👋🏻

I just went to add the test collector to a Hanami app, and noticed it was bringing along ActiveSupport as a dependency. I don't have that gem within my app, have a self-imposed challenge to keep it that way, and thought I'd investigate whether it's actually required here. I don't think it is?

There are three uses I've found and adjusted (in separate commits below):

* The `blank?`/`present?` convenience methods - which yes, are convenient, but also easily changed to pure Ruby options.
* `Hash#with_indifferent_access` - as far as I could see within the code, the hashes are created with symbol keys and strings aren't being used to refer to the keys at later points. The tests are also fine with this being removed, so, I hope this is fine!
* `ActiveSupport::Notifications` - which is a harder thing to replace, but it turns out it's only being used for ActiveRecord tracing. In which case I feel it's safe to presume that if ActiveSupport isn't already loaded by the app's test suite, then I'm pretty sure ActiveRecord won't be in play.

With all of these changes sorted, I've then shifted ActiveSupport to be a _development_ dependency. Tests are happy for me locally, and I've run this in the Hanami app's test suite and a Rails app's test suite, and both runs have appeared in the test analytics interface. If there's context I've missed though, please do let me know!