### PR TITLE
Add option to only send failures

### DIFF
--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -39,15 +39,17 @@ module Buildkite
       attr_accessor :session
       attr_accessor :tracing_enabled
       attr_accessor :artifact_path
+      attr_accessor :failures_only
       attr_accessor :env
       attr_accessor :batch_size
     end
 
-    def self.configure(hook:, token: nil, url: nil, tracing_enabled: true, artifact_path: nil, env: {})
+    def self.configure(hook:, token: nil, url: nil, tracing_enabled: true, artifact_path: nil, failures_only: false, env: {})
       self.api_token = (token || ENV["BUILDKITE_ANALYTICS_TOKEN"])&.strip
       self.url = url || DEFAULT_URL
       self.tracing_enabled = tracing_enabled
       self.artifact_path = artifact_path
+      self.failures_only = failures_only
       self.env = env
       self.batch_size = ENV.fetch("BUILDKITE_ANALYTICS_UPLOAD_BATCH_SIZE") { DEFAULT_UPLOAD_BATCH_SIZE }.to_i
       self.hook_into(hook)

--- a/lib/buildkite/test_collector/minitest_plugin/reporter.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/reporter.rb
@@ -12,6 +12,8 @@ module Buildkite::TestCollector::MinitestPlugin
       super
 
       if Buildkite::TestCollector.uploader
+        return if (result.passed? or result.skipped?) and Buildkite::TestCollector.failures_only
+
         if trace = Buildkite::TestCollector.uploader.traces[result.source_location]
           Buildkite::TestCollector.session.add_example_to_send_queue(result.source_location)
         end

--- a/lib/buildkite/test_collector/rspec_plugin/reporter.rb
+++ b/lib/buildkite/test_collector/rspec_plugin/reporter.rb
@@ -13,8 +13,9 @@ module Buildkite::TestCollector::RSpecPlugin
 
     def handle_example(notification)
       example = notification.example
-      trace = Buildkite::TestCollector.uploader.traces[example.id]
+      return if example.execution_result.status != :failed and Buildkite::TestCollector.failures_only
 
+      trace = Buildkite::TestCollector.uploader.traces[example.id]
       if trace
         trace.example = example
         if example.execution_result.status == :failed

--- a/spec/support/rspec_example_trace_helpers.rb
+++ b/spec/support/rspec_example_trace_helpers.rb
@@ -8,7 +8,7 @@ class FakeExecutionResult
     @status = status
     @skipped = skipped
     @pending_fixed = pending_fixed
-    @exception = status == :failed ? StandardError.new("fake error") : nil
+    @exception = (status == :failed or status == :pending) ? StandardError.new("fake error") : nil
   end
   def example_skipped?
     @skipped
@@ -16,12 +16,15 @@ class FakeExecutionResult
   def pending_fixed?
     @pending_fixed
   end
+  def pending_exception
+    @exception
+  end
 end
 
 module RSpecExampleTraceHelpers
   def fake_example(status:)
     example = double("RSpec::Core::Example")
-    allow(example).to receive(:execution_result) { FakeExecutionResult.new(status: :failed) }
+    allow(example).to receive(:execution_result) { FakeExecutionResult.new(status: status) }
     allow(example).to receive(:id) { "spec/fake/fake_spec[1:2:3]" }
     allow(example).to receive(:full_description) { "this is a fake example full description" }
     allow(example).to receive(:description) { "fake example name" }

--- a/spec/test_collector/minitest_plugin/reporter_spec.rb
+++ b/spec/test_collector/minitest_plugin/reporter_spec.rb
@@ -45,4 +45,76 @@ RSpec.describe Buildkite::TestCollector::MinitestPlugin::Reporter do
 
     reset_io(io)
   end
+
+  it "test reporter doesn't send a passed minitest result if failures_only is true" do
+    response = double("Fake Response", code: 200, body: {}, to_hash: {})
+    http = double("http", post: response)
+    allow(Buildkite::TestCollector::HTTPClient).to receive(:new) { http }
+    Buildkite::TestCollector.configure(
+      hook: :minitest,
+      token: "fake",
+      url: "http://fake.buildkite.example/v1/uploads",
+      failures_only: true,
+    )
+    io = StringIO.new
+    reporter = Buildkite::TestCollector::MinitestPlugin::Reporter.new(io, {})
+    trace = double("Trace", source_location: "test.rb:1")
+    allow(Buildkite::TestCollector.uploader).to receive(:traces) { { "test.rb:1" => trace } }
+    allow(Buildkite::TestCollector.session).to receive(:add_example_to_send_queue)
+    result = double("Result", assertions: 1, passed?: true, skipped?: false, source_location: "test.rb:1")
+
+    # does this raise an error?
+    reporter.record(result)
+
+    expect(Buildkite::TestCollector.session).not_to have_received(:add_example_to_send_queue)
+    reset_io(io)
+  end
+
+  it "test reporter doesn't send a skipped minitest result if failures_only is true" do
+    response = double("Fake Response", code: 200, body: {}, to_hash: {})
+    http = double("http", post: response)
+    allow(Buildkite::TestCollector::HTTPClient).to receive(:new) { http }
+    Buildkite::TestCollector.configure(
+      hook: :minitest,
+      token: "fake",
+      url: "http://fake.buildkite.example/v1/uploads",
+      failures_only: true,
+    )
+    io = StringIO.new
+    reporter = Buildkite::TestCollector::MinitestPlugin::Reporter.new(io, {})
+    trace = double("Trace", source_location: "test.rb:1")
+    allow(Buildkite::TestCollector.uploader).to receive(:traces) { { "test.rb:1" => trace } }
+    allow(Buildkite::TestCollector.session).to receive(:add_example_to_send_queue)
+    result = double("Result", assertions: 1, passed?: false, skipped?: true, source_location: "test.rb:1")
+
+    # does this raise an error?
+    reporter.record(result)
+
+    expect(Buildkite::TestCollector.session).not_to have_received(:add_example_to_send_queue)
+    reset_io(io)
+  end
+
+  it "test reporter sends a failed minitest result if failures_only is true" do
+    response = double("Fake Response", code: 200, body: {}, to_hash: {})
+    http = double("http", post: response)
+    allow(Buildkite::TestCollector::HTTPClient).to receive(:new) { http }
+    Buildkite::TestCollector.configure(
+      hook: :minitest,
+      token: "fake",
+      url: "http://fake.buildkite.example/v1/uploads",
+      failures_only: true,
+    )
+    io = StringIO.new
+    reporter = Buildkite::TestCollector::MinitestPlugin::Reporter.new(io, {})
+    trace = double("Trace", source_location: "test.rb:1")
+    allow(Buildkite::TestCollector.uploader).to receive(:traces) { { "test.rb:1" => trace } }
+    allow(Buildkite::TestCollector.session).to receive(:add_example_to_send_queue)
+    result = double("Result", assertions: 1, passed?: false, skipped?: false, source_location: "test.rb:1")
+
+    # does this raise an error?
+    reporter.record(result)
+
+    expect(Buildkite::TestCollector.session).to have_received(:add_example_to_send_queue)
+    reset_io(io)
+  end
 end

--- a/spec/test_collector/rspec_plugin/reporter_spec.rb
+++ b/spec/test_collector/rspec_plugin/reporter_spec.rb
@@ -43,4 +43,73 @@ RSpec.describe Buildkite::TestCollector::RSpecPlugin::Reporter do
 
     reset_io(io)
   end
+
+  it "test reporter doesn't send a passed RSpec example if failures_only is true" do
+    Buildkite::TestCollector.configure(
+      hook: :rspec,
+      token: "fake",
+      url: "http://fake.buildkite.localhost/v1/uploads",
+      failures_only: true,
+    )
+    io = StringIO.new
+    reporter = Buildkite::TestCollector::RSpecPlugin::Reporter.new(io)
+    a_example = fake_example(status: :passed)
+    trace = fake_trace(a_example)
+    allow(Buildkite::TestCollector.uploader).to receive(:traces) { trace }
+    allow(Buildkite::TestCollector.session).to receive(:add_example_to_send_queue)
+    notification = RSpec::Core::Notifications::ExampleNotification.for(a_example)
+    allow(notification).to receive(:colorized_message_lines) { [""] }
+
+    # does this raise an error?
+    reporter.handle_example(notification)
+
+    expect(Buildkite::TestCollector.session).not_to have_received(:add_example_to_send_queue)
+    reset_io(io)
+  end
+
+  it "test reporter doesn't send a pending RSpec example if failures_only is true" do
+    Buildkite::TestCollector.configure(
+      hook: :rspec,
+      token: "fake",
+      url: "http://fake.buildkite.localhost/v1/uploads",
+      failures_only: true,
+    )
+    io = StringIO.new
+    reporter = Buildkite::TestCollector::RSpecPlugin::Reporter.new(io)
+    a_example = fake_example(status: :pending)
+    trace = fake_trace(a_example)
+    allow(Buildkite::TestCollector.uploader).to receive(:traces) { trace }
+    allow(Buildkite::TestCollector.session).to receive(:add_example_to_send_queue)
+    notification = RSpec::Core::Notifications::ExampleNotification.for(a_example)
+    allow(notification).to receive(:colorized_message_lines) { [""] }
+
+    # does this raise an error?
+    reporter.handle_example(notification)
+
+    expect(Buildkite::TestCollector.session).not_to have_received(:add_example_to_send_queue)
+    reset_io(io)
+  end
+
+  it "test reporter sends a failed RSpec example if failures_only is true" do
+    Buildkite::TestCollector.configure(
+      hook: :rspec,
+      token: "fake",
+      url: "http://fake.buildkite.localhost/v1/uploads",
+      failures_only: true,
+    )
+    io = StringIO.new
+    reporter = Buildkite::TestCollector::RSpecPlugin::Reporter.new(io)
+    a_example = fake_example(status: :failed)
+    trace = fake_trace(a_example)
+    allow(Buildkite::TestCollector.uploader).to receive(:traces) { trace }
+    allow(Buildkite::TestCollector.session).to receive(:add_example_to_send_queue)
+    notification = RSpec::Core::Notifications::ExampleNotification.for(a_example)
+    allow(notification).to receive(:colorized_message_lines) { [""] }
+
+    # does this raise an error?
+    reporter.handle_example(notification)
+
+    expect(Buildkite::TestCollector.session).to have_received(:add_example_to_send_queue)
+    reset_io(io)
+  end
 end


### PR DESCRIPTION
In our use-cases, we're not interested in looking at successful test cases (and being billed for them), so we'd like an option to only send failures to the API.

This PR also fixes the `fake_example` helper that was ignoring the `status` argument and always creating failing examples.

I've tested this in our org and confirmed that it indeed only sends failed tests.