### PR TITLE
Create v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.5.0
+
+- Remove ActiveSupport as a primary dependancy #212 - @pat
+
 ## v2.4.0
 
 - Feature release: Output links to Test Analytic tests within the rspec log @meghan-kradolfer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## v2.4.0
 
-- Feature release: Output links to Test Analytic tests within the rspec log @meghan-kradolfer
+- Feature release: Output links to Test Analytic tests within the rspec log #209 - @meghan-kradolfer
 
 ## v2.3.2
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    buildkite-test_collector (2.4.0)
+    buildkite-test_collector (2.5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/buildkite/test_collector/version.rb
+++ b/lib/buildkite/test_collector/version.rb
@@ -2,7 +2,7 @@
 
 module Buildkite
   module TestCollector
-    VERSION = "2.4.0"
+    VERSION = "2.5.0"
     NAME = "buildkite-test_collector"
   end
 end


### PR DESCRIPTION
What's changed

- [Remove ActiveSupport as a primary dependancy](https://github.com/buildkite/test-collector-ruby/pull/212)