### PR TITLE
Trace spans can be filtered by a minimum duration

### DIFF
--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -38,7 +38,7 @@ module Buildkite
       attr_accessor :artifact_path
       attr_accessor :env
       attr_accessor :batch_size
-      attr_accessor :trace_min_seconds
+      attr_accessor :trace_min_duration
     end
 
     def self.configure(hook:, token: nil, url: nil, tracing_enabled: true, artifact_path: nil, env: {})
@@ -49,9 +49,9 @@ module Buildkite
       self.env = env
       self.batch_size = ENV.fetch("BUILDKITE_ANALYTICS_UPLOAD_BATCH_SIZE") { DEFAULT_UPLOAD_BATCH_SIZE }.to_i
 
-      trace_min_seconds_string = ENV["BUILDKITE_ANALYTICS_TRACE_MIN_SECONDS"]
-      if trace_min_seconds_string && !trace_min_seconds_string.empty?
-        self.trace_min_seconds = Float(trace_min_seconds_string)
+      trace_min_ms_string = ENV["BUILDKITE_ANALYTICS_TRACE_MIN_MS"]
+      if trace_min_ms_string && !trace_min_ms_string.empty?
+        self.trace_min_duration = Float(trace_min_ms_string) / 1000
       end
 
       self.hook_into(hook)

--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -50,8 +50,8 @@ module Buildkite
       self.batch_size = ENV.fetch("BUILDKITE_ANALYTICS_UPLOAD_BATCH_SIZE") { DEFAULT_UPLOAD_BATCH_SIZE }.to_i
 
       trace_min_ms_string = ENV["BUILDKITE_ANALYTICS_TRACE_MIN_MS"]
-      if trace_min_ms_string && !trace_min_ms_string.empty?
-        self.trace_min_duration = Float(trace_min_ms_string) / 1000
+      self.trace_min_duration = if trace_min_ms_string && !trace_min_ms_string.empty?
+        Float(trace_min_ms_string) / 1000
       end
 
       self.hook_into(hook)

--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -38,6 +38,7 @@ module Buildkite
       attr_accessor :artifact_path
       attr_accessor :env
       attr_accessor :batch_size
+      attr_accessor :trace_min_seconds
     end
 
     def self.configure(hook:, token: nil, url: nil, tracing_enabled: true, artifact_path: nil, env: {})
@@ -47,6 +48,12 @@ module Buildkite
       self.artifact_path = artifact_path
       self.env = env
       self.batch_size = ENV.fetch("BUILDKITE_ANALYTICS_UPLOAD_BATCH_SIZE") { DEFAULT_UPLOAD_BATCH_SIZE }.to_i
+
+      trace_min_seconds_string = ENV["BUILDKITE_ANALYTICS_TRACE_MIN_SECONDS"]
+      if trace_min_seconds_string && !trace_min_seconds_string.empty?
+        self.trace_min_seconds = Float(trace_min_seconds_string)
+      end
+
       self.hook_into(hook)
     end
 

--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -40,6 +40,7 @@ class Buildkite::TestCollector::CI
       "language_version" => RUBY_VERSION,
       "version" => Buildkite::TestCollector::VERSION,
       "collector" => "ruby-#{Buildkite::TestCollector::NAME}",
+      "trace_min_duration" => Buildkite::TestCollector.trace_min_duration&.to_s,
     }.select { |_, value| !value.nil? }
   end
 

--- a/lib/buildkite/test_collector/library_hooks/rspec.rb
+++ b/lib/buildkite/test_collector/library_hooks/rspec.rb
@@ -16,7 +16,9 @@ RSpec.configure do |config|
   end
 
   config.around(:each) do |example|
-    tracer = Buildkite::TestCollector::Tracer.new
+    tracer = Buildkite::TestCollector::Tracer.new(
+      min_seconds: Buildkite::TestCollector.trace_min_seconds,
+    )
 
     # The _buildkite prefix here is added as a safeguard against name collisions
     # as we are in the main thread

--- a/lib/buildkite/test_collector/library_hooks/rspec.rb
+++ b/lib/buildkite/test_collector/library_hooks/rspec.rb
@@ -17,7 +17,7 @@ RSpec.configure do |config|
 
   config.around(:each) do |example|
     tracer = Buildkite::TestCollector::Tracer.new(
-      min_seconds: Buildkite::TestCollector.trace_min_seconds,
+      min_duration: Buildkite::TestCollector.trace_min_duration,
     )
 
     # The _buildkite prefix here is added as a safeguard against name collisions

--- a/lib/buildkite/test_collector/minitest_plugin.rb
+++ b/lib/buildkite/test_collector/minitest_plugin.rb
@@ -11,7 +11,7 @@ module Buildkite::TestCollector::MinitestPlugin
     super
 
     tracer = Buildkite::TestCollector::Tracer.new(
-      min_seconds: Buildkite::TestCollector.trace_min_seconds,
+      min_duration: Buildkite::TestCollector.trace_min_duration,
     )
 
     # The _buildkite prefix here is added as a safeguard against name collisions

--- a/lib/buildkite/test_collector/minitest_plugin.rb
+++ b/lib/buildkite/test_collector/minitest_plugin.rb
@@ -9,7 +9,11 @@ require_relative "minitest_plugin/trace"
 module Buildkite::TestCollector::MinitestPlugin
   def before_setup
     super
-    tracer = Buildkite::TestCollector::Tracer.new
+
+    tracer = Buildkite::TestCollector::Tracer.new(
+      min_seconds: Buildkite::TestCollector.trace_min_seconds,
+    )
+
     # The _buildkite prefix here is added as a safeguard against name collisions
     # as we are in the main thread
     Thread.current[:_buildkite_tracer] = tracer

--- a/lib/buildkite/test_collector/tracer.rb
+++ b/lib/buildkite/test_collector/tracer.rb
@@ -55,10 +55,10 @@ module Buildkite::TestCollector
       class IncompleteSpan < StandardError; end
     end
 
-    def initialize(min_seconds: nil)
+    def initialize(min_duration: nil)
       @top = Span.new(:top, MonotonicTime.call, nil, {})
       @stack = [@top]
-      @min_seconds = min_seconds
+      @min_duration = min_duration
     end
 
     def enter(section, **detail)
@@ -71,12 +71,12 @@ module Buildkite::TestCollector
       current_span.end_at = MonotonicTime.call
       duration = current_span.duration
       @stack.pop
-      current_span.children.pop if @min_seconds && duration < @min_seconds
+      current_span.children.pop if @min_duration && duration < @min_duration
       nil # avoid ambiguous return type/value
     end
 
     def backfill(section, duration, **detail)
-      return if @min_seconds && duration < @min_seconds
+      return if @min_duration && duration < @min_duration
       now = MonotonicTime.call
       new_entry = Span.new(section, now - duration, now, detail)
       current_span.children << new_entry

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -410,5 +410,18 @@ RSpec.describe Buildkite::TestCollector::CI do
         end
       end
     end
+
+    context "with trace_min_duration" do
+      before do
+        fake_env("BUILDKITE_ANALYTICS_TRACE_MIN_MS", "123")
+        Buildkite::TestCollector.configure(hook: :rspec)
+      end
+
+      it "includes trace_min_duration in run_env" do
+        expect(Buildkite::TestCollector::CI.env).to include(
+          "trace_min_duration" => "0.123",
+        )
+      end
+    end
   end
 end

--- a/spec/test_collector/minitest_plugin/trace_spec.rb
+++ b/spec/test_collector/minitest_plugin/trace_spec.rb
@@ -2,6 +2,7 @@
 
 require "buildkite/test_collector/minitest_plugin/trace"
 require "minitest"
+require "pathname"
 
 RSpec.describe Buildkite::TestCollector::MinitestPlugin::Trace do
   subject(:trace) { Buildkite::TestCollector::MinitestPlugin::Trace.new(example, history: history) }
@@ -88,7 +89,7 @@ RSpec.describe Buildkite::TestCollector::MinitestPlugin::Trace do
       let(:rails) { double("Rails", root: Pathname.new("./")) }
 
       it "sets the filename" do
-        Rails = rails
+        stub_const("Rails", rails)
         expect(trace.as_hash[:file_name].split("/").last).to eq("method_double.rb")
       end
     end

--- a/spec/test_collector/tracer_spec.rb
+++ b/spec/test_collector/tracer_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Buildkite::TestCollector::Tracer do
-  subject(:tracer) { Buildkite::TestCollector::Tracer.new(min_seconds: min_seconds) }
-  let(:min_seconds) { nil }
+  subject(:tracer) { Buildkite::TestCollector::Tracer.new(min_duration: min_duration) }
+  let(:min_duration) { nil }
 
   it "can produce an empty :top span" do
     history = tracer.finalize.history
@@ -93,8 +93,8 @@ RSpec.describe Buildkite::TestCollector::Tracer do
       })
     end
 
-    describe "filtering traces by min_seconds" do
-      let(:min_seconds) { 2.0 }
+    describe "filtering traces by min_duration" do
+      let(:min_duration) { 2.0 }
 
       it "can filter traces by duration" do
         monotonic_time_queue << 10.0

--- a/spec/test_collector/tracer_spec.rb
+++ b/spec/test_collector/tracer_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+RSpec.describe Buildkite::TestCollector::Tracer do
+  subject(:tracer) { Buildkite::TestCollector::Tracer.new(min_seconds: min_seconds) }
+  let(:min_seconds) { nil }
+
+  it "can produce an empty :top span" do
+    history = tracer.finalize.history
+
+    expect(history).to match({
+      section: :top,
+      start_at: Float,
+      end_at: Float,
+      duration: history[:end_at] - history[:start_at],
+      detail: {},
+      children: [],
+    })
+  end
+
+  it "can produce trace spans with enter/leave or backfill" do
+    begin
+      tracer.enter(:hello, recipient: :world)
+    ensure
+      tracer.leave
+    end
+
+    tracer.backfill(:sql, 12.34, query: "SELECT hello FROM world")
+
+    begin
+      tracer.enter(:http, url: "https://example.com/")
+    ensure
+      tracer.leave
+    end
+
+    history = tracer.finalize.history
+
+    expect(history).to match({
+      section: :top,
+      start_at: Float,
+      end_at: Float,
+      duration: history[:end_at] - history[:start_at],
+      detail: {},
+      children: [
+        {
+          section: :hello,
+          start_at: Float,
+          end_at: Float,
+          duration: Float,
+          detail: {recipient: :world},
+          children: []
+        },
+        {
+          section: :sql,
+          start_at: Float,
+          end_at: Float,
+          duration: Float,
+          detail: {query: "SELECT hello FROM world"},
+          children: []
+        },
+        {
+          section: :http,
+          start_at: Float,
+          end_at: Float,
+          duration: Float,
+          detail: {url: "https://example.com/"},
+          children: []
+        },
+      ],
+    })
+  end
+
+  context "with mocked MonotonicTime" do
+    before do
+      allow(Buildkite::TestCollector::Tracer::MonotonicTime).to receive(:call) do
+        monotonic_time_queue.shift || raise("monotonic_time_queue empty")
+      end
+    end
+    let(:monotonic_time_queue) { [] }
+
+    it "produces expected timing for :top span" do
+      monotonic_time_queue << 11.1 # top start
+      monotonic_time_queue << 12.2 # top end
+
+      history = tracer.finalize.history
+
+      expect(history).to match({
+        section: :top,
+        start_at: 11.1,
+        end_at: 12.2,
+        duration: be_within(0.001).of(1.1),
+        detail: {},
+        children: [],
+      })
+    end
+
+    describe "filtering traces by min_seconds" do
+      let(:min_seconds) { 2.0 }
+
+      it "can filter traces by duration" do
+        monotonic_time_queue << 10.0
+        tracer
+
+        monotonic_time_queue << 20.0
+        tracer.enter(:fast_enter_leave)
+        monotonic_time_queue << 20.1
+        tracer.leave
+
+        monotonic_time_queue << 21.0
+        tracer.enter(:slow_enter_leave)
+        monotonic_time_queue << 25.0
+        tracer.leave
+
+        # skipped by #backfill: monotonic_time_queue << 30.2
+        tracer.backfill(:fast_backfill, 0.2)
+
+        monotonic_time_queue << 43.5
+        tracer.backfill(:slow_backfill, 3.5)
+
+        monotonic_time_queue << 50.0
+        history = tracer.finalize.history
+
+        expect(history[:start_at]).to eq(10.0)
+        expect(history[:end_at]).to eq(50.0)
+        expect(history[:duration]).to be_within(0.001).of(40.0)
+
+        expect(history[:children]).to match([
+          {
+            section: :slow_enter_leave,
+            start_at: 21.0,
+            end_at: 25.0,
+            duration: be_within(0.001).of(4.0),
+            detail: {},
+            children: [],
+          },
+          {
+            section: :slow_backfill,
+            start_at: be_within(0.001).of(40.0),
+            end_at: 43.5,
+            duration: be_within(0.001).of(3.5),
+            detail: {},
+            children: [],
+          },
+        ])
+      end
+    end
+  end
+end

--- a/spec/test_collector_spec.rb
+++ b/spec/test_collector_spec.rb
@@ -1,12 +1,19 @@
 # frozen_string_literal: true
 
 RSpec.describe Buildkite::TestCollector do
+  # Perhaps there's a better way to make a stubbed ENV overlay that resets between tests.
+  # We could probably use allow(ENV).to receive(...) although I find that more fragile.
+  # Also, I hadn't seen spec/support/fake_env_helpers.rb when I wrote this :|
+  ENV_REAL = ENV
+  let(:env_overlay) { Hash.new { |_h, k| ENV_REAL[k] } }
+  before { stub_const("ENV", env_overlay) }
+
   context "RSpec" do
     let(:hook) { :rspec }
 
     it "can configure api_token and url" do
       analytics = Buildkite::TestCollector
-      ENV["BUILDKITE_ANALYTICS_TOKEN"] = "MyToken"
+      env_overlay["BUILDKITE_ANALYTICS_TOKEN"] = "MyToken"
 
       analytics.configure(hook: hook)
 
@@ -22,6 +29,19 @@ RSpec.describe Buildkite::TestCollector do
 
       expect(analytics.env).to match env
     end
+
+    it "can configure (and unconfigure) trace_min_duration" do
+      Buildkite::TestCollector.configure(hook: hook)
+      expect(Buildkite::TestCollector.trace_min_duration).to eq(nil)
+
+      env_overlay["BUILDKITE_ANALYTICS_TRACE_MIN_MS"] = "123"
+      Buildkite::TestCollector.configure(hook: hook)
+      expect(Buildkite::TestCollector.trace_min_duration).to eq(0.123)
+
+      env_overlay.delete("BUILDKITE_ANALYTICS_TRACE_MIN_MS")
+      Buildkite::TestCollector.configure(hook: hook)
+      expect(Buildkite::TestCollector.trace_min_duration).to eq(nil)
+    end
   end
 
   context "Minitest" do
@@ -29,7 +49,7 @@ RSpec.describe Buildkite::TestCollector do
 
     it "can configure api_token and url" do
       analytics = Buildkite::TestCollector
-      ENV["BUILDKITE_ANALYTICS_TOKEN"] = "MyToken"
+      env_overlay["BUILDKITE_ANALYTICS_TOKEN"] = "MyToken"
 
       analytics.configure(hook: hook)
 


### PR DESCRIPTION
Introduce the ability to filter trace spans by a minimum duration, so that fast spans can be discarded and only slow (interesting) spans are kept in memory and uploaded.

Configurable using `BUILDKITE_ANALYTICS_TRACE_MIN_SECONDS` (decimal value) in environment.