### PR TITLE
Run tests on a new queue

### DIFF
--- a/buildkite.yaml
+++ b/buildkite.yaml
@@ -1,3 +1,6 @@
+agents:
+  queue: hosted
+
 steps:
   - label: ":rspec: Tests :ruby: 3.3-rc"
     command:
@@ -5,7 +8,7 @@ steps:
       - "bundle exec rake"
     plugins:
       - docker#v3.7.0:
-          image: "445615400570.dkr.ecr.us-east-1.amazonaws.com/ecr-public/docker/library/ruby:3.3-rc"
+          image: "public.ecr.aws/docker/library/ruby:3.3-rc"
     soft_fail: true
 
   - label: ":rspec: Tests :ruby: {{matrix}}"
@@ -14,7 +17,7 @@ steps:
       - "bundle exec rake"
     plugins:
       - docker#v3.7.0:
-          image: "445615400570.dkr.ecr.us-east-1.amazonaws.com/ecr-public/docker/library/ruby:{{matrix}}"
+          image: "public.ecr.aws/docker/library/ruby:{{matrix}}"
     matrix:
       - "latest"
       - "3.2"


### PR DESCRIPTION
We're starting to test a new queue, and I'm looking for projects to experiment with. These new agents are quite different, but have docker and bash so I expect things should Just Work.

If there's any surprises, we can safely revert.

The new agents aren't authenticated to ECR, so I've switched to loading ruby docker images from the public ECR gallery. That's our preferred style these days anyway - agents that are authenticated to ECR will transparently use ECR as a cache. We don't need to explicitly use ECR images.