### PR TITLE
Update CI pipeline to reflect Ruby 3.3 has been released

### DIFF
--- a/buildkite.yaml
+++ b/buildkite.yaml
@@ -2,15 +2,6 @@ agents:
   queue: hosted
 
 steps:
-  - label: ":rspec: Tests :ruby: 3.3-rc"
-    command:
-      - "bundle"
-      - "bundle exec rake"
-    plugins:
-      - docker#v3.7.0:
-          image: "public.ecr.aws/docker/library/ruby:3.3-rc"
-    soft_fail: true
-
   - label: ":rspec: Tests :ruby: {{matrix}}"
     command:
       - "bundle"
@@ -20,6 +11,7 @@ steps:
           image: "public.ecr.aws/docker/library/ruby:{{matrix}}"
     matrix:
       - "latest"
+      - "3.3"
       - "3.2"
       - "3.1"
       - "3.0"


### PR DESCRIPTION
Ruby 3.3 has been released so we don't need to run the tests against the
RC version of Ruby. I've removed the RC step completely, but it can
be reintroduced if we want to test against the next RC in the future.

I've also added 3.3 to the standard build matrix.
