### PR TITLE
Add configurable span filters.

### DIFF
--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -39,12 +39,14 @@ module Buildkite
       attr_accessor :env
       attr_accessor :batch_size
       attr_accessor :trace_min_duration
+      attr_accessor :trace_ignore_span
     end
 
-    def self.configure(hook:, token: nil, url: nil, tracing_enabled: true, artifact_path: nil, env: {})
+    def self.configure(hook:, token: nil, url: nil, tracing_enabled: true, trace_ignore_span: nil, artifact_path: nil, env: {})
       self.api_token = (token || ENV["BUILDKITE_ANALYTICS_TOKEN"])&.strip
       self.url = url || DEFAULT_URL
       self.tracing_enabled = tracing_enabled
+      self.trace_ignore_span = trace_ignore_span || ->(span) { false }
       self.artifact_path = artifact_path
       self.env = env
       self.batch_size = ENV.fetch("BUILDKITE_ANALYTICS_UPLOAD_BATCH_SIZE") { DEFAULT_UPLOAD_BATCH_SIZE }.to_i

--- a/lib/buildkite/test_collector/tracer.rb
+++ b/lib/buildkite/test_collector/tracer.rb
@@ -71,7 +71,16 @@ module Buildkite::TestCollector
       current_span.end_at = MonotonicTime.call
       duration = current_span.duration
       @stack.pop
-      current_span.children.pop if @min_duration && duration < @min_duration
+
+      if @min_duration && duration < @min_duration
+        current_span.children.pop
+        return nil
+      end
+
+      if Buildkite::TestCollector.trace_ignore_span.call(current_span.children.last)
+        current_span.children.pop
+      end
+
       nil # avoid ambiguous return type/value
     end
 

--- a/spec/test_collector/tracer_spec.rb
+++ b/spec/test_collector/tracer_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Buildkite::TestCollector::Tracer do
-  subject(:tracer) { Buildkite::TestCollector::Tracer.new(min_duration: min_duration) }
-  let(:min_duration) { nil }
+  subject(:tracer) { Buildkite::TestCollector::Tracer.new }
+  before { Buildkite::TestCollector.span_filters = [] }
 
   it "can produce an empty :top span" do
     history = tracer.finalize.history
@@ -70,13 +70,9 @@ RSpec.describe Buildkite::TestCollector::Tracer do
   end
 
   context "span filtering" do
-    let(:ignore_span_callback) do
-      ->(span) { span.section == :ignore_me }
-    end
-
-    before do
-      allow(Buildkite::TestCollector).to receive(:trace_ignore_span).and_return(ignore_span_callback)
-    end
+    let(:filter) { ->(span) { span.section != :ignore_me } }
+    before { Buildkite::TestCollector.span_filters << filter }
+    after { Buildkite::TestCollector.span_filters.delete(filter) }
 
     it "can filter out spans using provided ignore_span_callback" do
       tracer.backfill(:sql, 12.34, query: "SELECT hello FROM world")
@@ -142,6 +138,11 @@ RSpec.describe Buildkite::TestCollector::Tracer do
 
     describe "filtering traces by min_duration" do
       let(:min_duration) { 2.0 }
+      before do
+        fake_env("BUILDKITE_ANALYTICS_TOKEN", "token")
+        fake_env("BUILDKITE_ANALYTICS_TRACE_MIN_MS", (min_duration * 1000).to_s)
+        Buildkite::TestCollector.configure(hook: :minitest)
+      end
 
       it "can filter traces by duration" do
         monotonic_time_queue << 10.0
@@ -157,7 +158,7 @@ RSpec.describe Buildkite::TestCollector::Tracer do
         monotonic_time_queue << 25.0
         tracer.leave
 
-        # skipped by #backfill: monotonic_time_queue << 30.2
+        monotonic_time_queue << 30.2
         tracer.backfill(:fast_backfill, 0.2)
 
         monotonic_time_queue << 43.5


### PR DESCRIPTION
When using the collector, sometimes there can many uninteresting spans in the trace from things like selenium or other framework noise. This adds a seam to allow users to have control of filtering out uninteresting trace spans.



## Usage

```rb
ignore_selenium_requests = ->(span) do
  return true unless span[:section] == "http"

  !span.dig(:detail, :url) =~ /^http://selenium:4444//
end

Buildkite::TestCollector.configure(hook: :rspec)
Buildkite::TestCollector.span_filters << ignore_selenium_requests
```

This doesn't need to be a lambda, any `#call`-able will work, as long as it returns a truthy value from the callback when we want to retain the span.

Multiple `span_filters` can be provided, and as long they _all_ return a truthy value, then the span will be retained, this allows composing multiple filters together.

This would be a public interface to the library, so I'm happy to workshop the naming/semantics.