### PR TITLE
Handle http response errors during upoad.

### DIFF
--- a/lib/buildkite/test_collector/http_client.rb
+++ b/lib/buildkite/test_collector/http_client.rb
@@ -38,7 +38,13 @@ module Buildkite::TestCollector
 
       contact.body = compressed_body.string
 
-      http.request(contact)
+      response = http.request(contact)
+
+      if response.is_a?(Net::HTTPSuccess)
+        response
+      else
+        raise "HTTP Request Failed: #{response.code} #{response.message}"
+      end
     end
 
     def metadata

--- a/lib/buildkite/test_collector/uploader.rb
+++ b/lib/buildkite/test_collector/uploader.rb
@@ -25,7 +25,8 @@ module Buildkite::TestCollector
       OpenSSL::SSL::SSLError,
       OpenSSL::SSL::SSLErrorWaitReadable,
       EOFError,
-      Errno::ETIMEDOUT
+      Errno::ETIMEDOUT,
+      # TODO: some retries for server-side error would be great.
     ]
 
     def self.tracer
@@ -38,7 +39,7 @@ module Buildkite::TestCollector
       http = Buildkite::TestCollector::HTTPClient.new(Buildkite::TestCollector.url)
 
       Thread.new do
-        response = begin
+        begin
           upload_attempts ||= 0
           http.post_json(data)
         rescue *Buildkite::TestCollector::Uploader::RETRYABLE_UPLOAD_ERRORS => e

--- a/spec/test_collector/uploader_spec.rb
+++ b/spec/test_collector/uploader_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Buildkite::TestCollector::Uploader do
+  let(:http_client_double) { instance_double(Buildkite::TestCollector::HTTPClient) }
+  let(:api_token) { 'fake_api_token' }
+
+  before do
+    allow(Buildkite::TestCollector::HTTPClient).to receive(:new).and_return(http_client_double)
+    allow(Thread).to receive(:new).and_yield
+    allow(Buildkite::TestCollector).to receive(:api_token).and_return(api_token)
+    allow(Buildkite::TestCollector).to receive(:url).and_return('https://fake-url.com')
+  end
+
+  describe '.upload' do
+    it 'posts data to the HTTP client' do
+      expect(http_client_double).to receive(:post_json).with([{some: 'data'}])
+      described_class.upload([{some: 'data'}])
+    end
+
+    context 'when there is RuntimeError' do
+      before do
+        allow(http_client_double).to receive(:post_json).and_raise(RuntimeError)
+        allow($stderr).to receive(:puts)
+      end
+
+      it 'logs an error message' do
+        expect($stderr).to receive(:puts).with(include("experienced an error when sending your data"))
+        described_class.upload([{some: 'data'}])
+      end
+    end
+  end
+end


### PR DESCRIPTION
part of PIE-2813

Fix uploader so it will throw a runtime error if backend does not return 2xx. 
This will result in a log message if any upload fails.

Note it will not fail a build if the upload fails. 