### PR TITLE
Update references from Test Analytics to Test Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **DEPRECATION NOTICE**
 Versions prior to 2.1.x are unsupported and will not work after mid-2023. Please upgrade to the latest version.
 
-Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collectors for Ruby test frameworks ✨
+Official [Buildkite Test Engine](https://buildkite.com/platform/test-engine) collectors for Ruby test frameworks ✨
 
 ⚒ **Supported test frameworks:** RSpec, Minitest, and [more coming soon](https://github.com/buildkite/test-collector-ruby/issues?q=is%3Aissue+is%3Aopen+label%3A%22test+frameworks%22).
 
@@ -68,13 +68,13 @@ BUILDKITE_ANALYTICS_TOKEN=xyz rake
 Add the `BUILDKITE_ANALYTICS_TOKEN` secret to your CI, push your changes to a branch, and open a pull request 🎉
 
 ```bash
-git checkout -b add-buildkite-test-analytics
-git commit -am "Add Buildkite Test Analytics"
-git push origin add-buildkite-test-analytics
+git checkout -b add-buildkite-test-engine
+git commit -am "Add Buildkite Test Engine"
+git push origin add-buildkite-test-engine
 ```
 
 ### VCR
-If your test suites use [VCR](https://github.com/vcr/vcr) to stub network requests, you'll need to modify the config to allow actual network requests to Test Analytics.
+If your test suites use [VCR](https://github.com/vcr/vcr) to stub network requests, you'll need to modify the config to allow actual network requests to Test Engine.
 
 ```
 VCR.configure do |c|
@@ -119,7 +119,7 @@ And run the tests:
 bundle exec rspec
 ```
 
-Useful resources for developing collectors include the [Buildkite Test Analytics docs](https://buildkite.com/docs/test-analytics).
+Useful resources for developing collectors include the [Buildkite Test Engine docs](https://buildkite.com/docs/test-engine).
 
 See [DESIGN.md](DESIGN.md) for an overview of the design of this gem.
 

--- a/buildkite-test_collector.gemspec
+++ b/buildkite-test_collector.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Buildkite"]
   spec.email         = ["support+analytics@buildkite.com"]
 
-  spec.summary       = "Track test executions and report to Buildkite Test Analytics"
+  spec.summary       = "Track test executions and report to Buildkite Test Engine"
   spec.homepage      = "https://github.com/buildkite/test-collector-ruby"
   spec.license       = "MIT"
 

--- a/lib/buildkite/test_collector/test_links_plugin/formatter.rb
+++ b/lib/buildkite/test_collector/test_links_plugin/formatter.rb
@@ -23,7 +23,7 @@ module Buildkite::TestCollector::TestLinksPlugin
       # return if suite url is nil
       return if metadata['suite_url'].nil?
 
-      @output << "\n\n🔥 \x1b[31mTest Analytics failures 🔥\n"
+      @output << "\n\n🔥 \x1b[31mTest Engine failures 🔥\n"
       @output << '_____________________________'
       @output << "\n\n"
 

--- a/spec/test_collector/test_links/formatter_spec.rb
+++ b/spec/test_collector/test_links/formatter_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Buildkite::TestCollector::TestLinksPlugin::Formatter do
         allow(http_client).to receive(:metadata).and_return(OpenStruct.new(code: '200', body: response))
         formatter.dump_failures(notification)
 
-        expect(io.string.strip).to include('Test Analytics failures')
+        expect(io.string.strip).to include('Test Engine failures')
         expect(io.string.strip).to include("#{suite_url}/tests/#{scope_name_digest}")
         expect(io.string.strip).to include("#{scope} #{name}")
       end


### PR DESCRIPTION
With the recent relaunch and rebranding of Test Engine, this PR updates all references within the collector from "Test Analytics" to "Test Engine."