### PR TITLE
Add execution_count as part of our upload.run_env

### DIFF
--- a/lib/buildkite/test_collector/http_client.rb
+++ b/lib/buildkite/test_collector/http_client.rb
@@ -25,7 +25,9 @@ module Buildkite::TestCollector
       data_set = data.map(&:as_hash)
 
       body = {
-        run_env: Buildkite::TestCollector::CI.env,
+        run_env: Buildkite::TestCollector::CI.env.merge({
+          execution_count: data_set.size
+        }),
         format: "json",
         data: data_set
       }.to_json

--- a/spec/test_collector/http_client_spec.rb
+++ b/spec/test_collector/http_client_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe Buildkite::TestCollector::HTTPClient do
         "language_version" => RUBY_VERSION,
         "version": Buildkite::TestCollector::VERSION,
         "collector": "ruby-buildkite-test_collector",
-        "test": "test_value"
+        "test": "test_value",
+        "execution_count": 1
       },
       "format": "json",
       "data": [{


### PR DESCRIPTION
It's proven tricky to debug individual upload due to the fact that they are normally gzipped. Correlating gzipped content with other parts of our system is labor intensive. 

For example, finding how many executions do each upload has is a pretty common task but really non-trivial to do in our current backend. 

This PR add a execution_count fields on upload metadata `run_env`, this will allow us to answer the question above trivially. 