### PR TITLE
Remove call to deleted formatter

### DIFF
--- a/lib/buildkite/test_collector/library_hooks/rspec.rb
+++ b/lib/buildkite/test_collector/library_hooks/rspec.rb
@@ -11,7 +11,6 @@ Buildkite::TestCollector.uploader = Buildkite::TestCollector::Uploader
 RSpec.configure do |config|
   config.before(:suite) do
     config.add_formatter Buildkite::TestCollector::RSpecPlugin::Reporter
-    config.add_formatter Buildkite::TestCollector::TestLinksPlugin::Formatter
   end
 
   config.around(:each) do |example|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,15 @@ require "active_support/notifications"
 
 Dir["spec/support/**/*.rb"].each { |f| require File.expand_path(f) }
 
+# Set up the various hooks that the collector uses.
+#
+# This provides some coverage for the code in
+# lib/buildkite/test_collector/library_hooks/rspec.rb which is otherwise
+# currently untested. At present this suite is not connected to Buildkite
+# Test Engine so these hooks will all be noops. However this does give us
+# some regression testing for the code that sets up the hooks themselves.
+Buildkite::TestCollector.configure(hook: :rspec)
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
This formatter was removed in
https://github.com/buildkite/test-collector-ruby/pull/228 but this reference was accidentally left behind.