### PR TITLE
HTTPClient: minor refactor; naming, constructor args

### DIFF
--- a/lib/buildkite/test_collector/uploader.rb
+++ b/lib/buildkite/test_collector/uploader.rb
@@ -36,7 +36,10 @@ module Buildkite::TestCollector
     def self.upload(data)
       return false unless Buildkite::TestCollector.api_token
 
-      http = Buildkite::TestCollector::HTTPClient.new(Buildkite::TestCollector.url)
+      http = Buildkite::TestCollector::HTTPClient.new(
+        url: Buildkite::TestCollector.url,
+        api_token: Buildkite::TestCollector.api_token,
+      )
 
       Thread.new do
         begin

--- a/spec/test_collector/http_client_spec.rb
+++ b/spec/test_collector/http_client_spec.rb
@@ -3,7 +3,12 @@
 require 'ostruct'
 
 RSpec.describe Buildkite::TestCollector::HTTPClient do
-  subject { described_class.new("buildkite.localhost") }
+  subject do
+    Buildkite::TestCollector::HTTPClient.new(
+      url: "http://buildkite.localhost/v1/uploads",
+      api_token: "thetoken",
+    )
+  end
 
   let(:example_group) { OpenStruct.new(metadata: { full_description: "i love to eat pies" }) }
   let(:execution_result) { OpenStruct.new(status: :passed) }
@@ -59,7 +64,11 @@ RSpec.describe Buildkite::TestCollector::HTTPClient do
     allow(Net::HTTP).to receive(:new).and_return(http_double)
     allow(http_double).to receive(:use_ssl=)
 
-    allow(Net::HTTP::Post).to receive(:new).with("buildkite.localhost", {"Authorization"=>"Token token=\"my-cool-token\"", "Content-Encoding"=>"gzip", "Content-Type"=>"application/json"}).and_return(post_double)
+    allow(Net::HTTP::Post).to receive(:new).with("/v1/uploads", {
+      "Authorization" => "Token token=\"thetoken\"",
+      "Content-Encoding" => "gzip",
+      "Content-Type" => "application/json",
+    }).and_return(post_double)
 
     allow(ENV).to receive(:[]).and_call_original
     fake_env("BUILDKITE_ANALYTICS_KEY", "build-123")
@@ -70,7 +79,7 @@ RSpec.describe Buildkite::TestCollector::HTTPClient do
     fake_env("GITHUB_RUN_NUMBER", nil)
     fake_env("CIRCLE_BUILD_NUM", nil)
 
-    Buildkite::TestCollector.configure(hook: :rspec, token: "my-cool-token", env: { "test" => "test_value" })
+    Buildkite::TestCollector.configure(hook: :rspec, token: "thetoken", env: { "test" => "test_value" })
   end
 
   describe "#post_json" do


### PR DESCRIPTION
Summary:
- rename `contact` to `request` (and `contact_uri` to `endpoint_uri`)
- take `api_token` as an arg, rather than reaching into global config

I'm extracting this refactor from another change which will add tagging support, to make that other change smaller.