### PR TITLE
HTTPClient: `#post_upload` replaces `#post_json`; receives `run_env`

### DIFF
--- a/lib/buildkite/test_collector/http_client.rb
+++ b/lib/buildkite/test_collector/http_client.rb
@@ -9,7 +9,7 @@ module Buildkite::TestCollector
       @api_token = api_token
     end
 
-    def post_json(data)
+    def post_upload(data:, run_env:)
       endpoint_uri = URI.parse(url)
 
       http = Net::HTTP.new(endpoint_uri.host, endpoint_uri.port)
@@ -24,7 +24,7 @@ module Buildkite::TestCollector
       data_set = data.map(&:as_hash)
 
       body = {
-        run_env: Buildkite::TestCollector::CI.env,
+        run_env: run_env,
         format: "json",
         data: data_set
       }.to_json

--- a/lib/buildkite/test_collector/uploader.rb
+++ b/lib/buildkite/test_collector/uploader.rb
@@ -44,11 +44,14 @@ module Buildkite::TestCollector
       Thread.new do
         begin
           upload_attempts ||= 0
-          http.post_json(data)
+          http.post_upload(
+            data: data,
+            run_env: Buildkite::TestCollector::CI.env,
+          )
+
         rescue *Buildkite::TestCollector::Uploader::RETRYABLE_UPLOAD_ERRORS => e
-          if (upload_attempts += 1) < MAX_UPLOAD_ATTEMPTS
-            retry
-          end
+          retry if (upload_attempts += 1) < MAX_UPLOAD_ATTEMPTS
+
         rescue StandardError => e
           $stderr.puts e
           $stderr.puts "#{Buildkite::TestCollector::NAME} #{Buildkite::TestCollector::VERSION} experienced an error when sending your data, you may be missing some executions for this run."

--- a/spec/test_collector/session_spec.rb
+++ b/spec/test_collector/session_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Buildkite::TestCollector::Session do
-  subject { described_class.new }
+  subject { Buildkite::TestCollector::Session.new }
+
   let(:data) do
     {
       "test-1": "test-1-data",

--- a/spec/test_collector/uploader_spec.rb
+++ b/spec/test_collector/uploader_spec.rb
@@ -13,19 +13,24 @@ RSpec.describe Buildkite::TestCollector::Uploader do
 
   describe '.upload' do
     it 'posts data to the HTTP client' do
-      expect(http_client_double).to receive(:post_json).with([{some: 'data'}])
-      described_class.upload([{some: 'data'}])
+      expect(http_client_double).to receive(:post_upload).with(
+        data: [{some: 'data'}],
+        run_env: hash_including("collector" => "ruby-buildkite-test_collector"),
+      )
+
+      Buildkite::TestCollector::Uploader.upload([{some: 'data'}])
     end
 
     context 'when there is RuntimeError' do
       before do
-        allow(http_client_double).to receive(:post_json).and_raise(RuntimeError)
+        allow(http_client_double).to receive(:post_upload).and_raise(RuntimeError)
         allow($stderr).to receive(:puts)
       end
 
       it 'logs an error message' do
         expect($stderr).to receive(:puts).with(include("experienced an error when sending your data"))
-        described_class.upload([{some: 'data'}])
+
+        Buildkite::TestCollector::Uploader.upload([{some: 'data'}])
       end
     end
   end


### PR DESCRIPTION
Further to #233, refactor `HTTPClient#post_upload` (previously called `#post_json`) to receive `run_env` as a keyword argument, instead of reaching out to `Buildkite::TestCollector::CI.env` (which is then dependent on environment variables etc and harder to test).

`Buildkite::TestCollector::CI.env` itself is tested separately, so we still have coverage across the generated `run_env`.

I'm extracting this refactor from another change which will add tagging support, to make that other change smaller.

Related:
- https://github.com/buildkite/test-collector-ruby/pull/233