### PR TITLE
Buildkite::TestCollector.tags: specify tags for all executions

### DIFF
--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -36,17 +36,19 @@ module Buildkite
       attr_accessor :tracing_enabled
       attr_accessor :artifact_path
       attr_accessor :env
+      attr_accessor :tags
       attr_accessor :batch_size
       attr_accessor :trace_min_duration
       attr_accessor :span_filters
     end
 
-    def self.configure(hook:, token: nil, url: nil, tracing_enabled: true, artifact_path: nil, env: {})
+    def self.configure(hook:, token: nil, url: nil, tracing_enabled: true, artifact_path: nil, env: {}, tags: {})
       self.api_token = (token || ENV["BUILDKITE_ANALYTICS_TOKEN"])&.strip
       self.url = url || DEFAULT_URL
       self.tracing_enabled = tracing_enabled
       self.artifact_path = artifact_path
       self.env = env
+      self.tags = tags
       self.batch_size = ENV.fetch("BUILDKITE_ANALYTICS_UPLOAD_BATCH_SIZE") { DEFAULT_UPLOAD_BATCH_SIZE }.to_i
 
       trace_min_ms_string = ENV["BUILDKITE_ANALYTICS_TRACE_MIN_MS"]

--- a/lib/buildkite/test_collector/http_client.rb
+++ b/lib/buildkite/test_collector/http_client.rb
@@ -9,7 +9,7 @@ module Buildkite::TestCollector
       @api_token = api_token
     end
 
-    def post_upload(data:, run_env:)
+    def post_upload(data:, run_env:, tags:)
       endpoint_uri = URI.parse(url)
 
       http = Net::HTTP.new(endpoint_uri.host, endpoint_uri.port)
@@ -25,6 +25,7 @@ module Buildkite::TestCollector
 
       body = {
         run_env: run_env,
+        tags: tags,
         format: "json",
         data: data_set
       }.to_json

--- a/lib/buildkite/test_collector/uploader.rb
+++ b/lib/buildkite/test_collector/uploader.rb
@@ -47,6 +47,7 @@ module Buildkite::TestCollector
           http.post_upload(
             data: data,
             run_env: Buildkite::TestCollector::CI.env,
+            tags: Buildkite::TestCollector.tags,
           )
 
         rescue *Buildkite::TestCollector::Uploader::RETRYABLE_UPLOAD_ERRORS => e

--- a/spec/test_collector/http_client_spec.rb
+++ b/spec/test_collector/http_client_spec.rb
@@ -33,6 +33,9 @@ RSpec.describe Buildkite::TestCollector::HTTPClient do
       "run_env": {
         "key": "build-123",
       },
+      "tags": {
+        "language.name" => "ruby"
+      },
       "format": "json",
       "data": [
         {
@@ -58,6 +61,7 @@ RSpec.describe Buildkite::TestCollector::HTTPClient do
   end
 
   let(:run_env) { {"key" => "build-123"} }
+  let(:tags) { {"language.name" => "ruby"} }
 
   before do
     allow(Net::HTTP).to receive(:new).and_return(http_double)
@@ -79,6 +83,7 @@ RSpec.describe Buildkite::TestCollector::HTTPClient do
       subject.post_upload(
         data: [trace],
         run_env: run_env,
+        tags: tags,
       )
     end
 
@@ -93,6 +98,7 @@ RSpec.describe Buildkite::TestCollector::HTTPClient do
         subject.post_upload(
           data: [trace],
           run_env: run_env,
+          tags: tags,
         )
       }.to raise_error(RuntimeError, "HTTP Request Failed: 500 Internal Server Error")
     end

--- a/spec/test_collector/uploader_spec.rb
+++ b/spec/test_collector/uploader_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Buildkite::TestCollector::Uploader do
       expect(http_client_double).to receive(:post_upload).with(
         data: [{some: 'data'}],
         run_env: hash_including("collector" => "ruby-buildkite-test_collector"),
+        tags: {},
       )
 
       Buildkite::TestCollector::Uploader.upload([{some: 'data'}])


### PR DESCRIPTION
Allow `tags` to be specified for all executions uploaded by the collector; they will propagate onto all the test results (executions) within.

Arbitrary tags may not be supported yet; this is an upcoming/experimental feature. Reach out to Buildkite support for more information if you're interested.

Related:
- https://github.com/buildkite-plugins/test-collector-buildkite-plugin/pull/81
- Based on:
  - #233
  - #234 