### PR TITLE
Add Ruby 3.4 to Buildkite build matrix

### DIFF
--- a/buildkite.yaml
+++ b/buildkite.yaml
@@ -12,6 +12,7 @@ steps:
           image: "public.ecr.aws/docker/library/ruby:{{matrix}}"
     matrix:
       - "latest"
+      - "3.4"
       - "3.3"
       - "3.2"
       - "3.1"


### PR DESCRIPTION
Ruby 3.4 was released on Dec 2024. Time to build against it!
