### PR TITLE
Create new pipeline for releasing to rubygems

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -1,0 +1,18 @@
+agents:
+  queue: hosted
+
+steps:
+  - block: "OK to release?"
+
+  - command: ".buildkite/steps/release-gem"
+    label: ":rubygems:"
+    if: build.tag != null
+    plugins:
+      - rubygems-oidc#v0.2.0:
+          role: "rg_oidc_akr_fy1x4px4yjwd1rdhkkda"
+      - docker#v5.12.0:
+          image: "ruby:3.4"
+          environment:
+            - GEM_HOST_API_KEY
+            - BUILDKITE_TAG
+

--- a/.buildkite/steps/release-gem
+++ b/.buildkite/steps/release-gem
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ -z "${GEM_HOST_API_KEY}" ]; then
+  echo "GEM_HOST_API_KEY environment variable not found"
+  exit 1
+fi
+
+if [ -z "${BUILDKITE_TAG}" ]; then
+  echo "BUILDKITE_TAG environment variable not found"
+  exit 1
+fi
+
+cd $(dirname $0)/../..
+
+echo "--- Inspecting tag and version"
+
+echo "BUILDKITE_TAG: ${BUILDKITE_TAG}"
+
+if [[ ! "${BUILDKITE_TAG}" == v* ]]; then
+  echo "We will only try to publish to rubygems when the tag starts with 'v'"
+  exit 1
+fi
+
+VERSION=$(echo "${BUILDKITE_TAG}" | sed "s/^v//")
+GEM_FILENAME="buildkite-test_collector-${VERSION}.gem"
+
+echo "Version to release: ${VERSION}"
+
+echo "--- Building gem"
+
+gem build buildkite-test_collector.gemspec
+
+if [ ! -f "${GEM_FILENAME}" ]; then
+  echo
+  echo "ERROR: Expected compiled gem to be '${GEM_FILENAME}' but file not found"
+  echo "Does the gemspec specify version '${BUILDKITE_TAG}'?"
+  echo
+  echo "Gem files found:"
+  echo
+  ls *.gem
+  echo
+  exit 1
+fi
+
+echo "--- Check if version already exists on rubygems.org"
+
+if [ $(curl -s -o /dev/null -w "%{http_code}" https://rubygems.org/api/v2/rubygems/buildkite-test_collector/versions/${VERSION}.json) == "200" ]; then
+  echo "Gem version ${VERSION} already found on rubygems, skipping release"
+  exit 1
+fi
+
+echo "--- publish gem"
+
+gem push "${GEM_FILENAME}"

--- a/README.md
+++ b/README.md
@@ -131,14 +131,15 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/buildk
 
 1. Bump the version in `version.rb` and run `bundle` to update the `Gemfile.lock`.
 1. Update the CHANGELOG.md with your new version and a description of your changes.
-1. Git tag your changes and push
-```
-git tag v.x.x.x
-git push --tags
-```
+
 Once your PR is merged to `main`:
 
-1. Run `rake release` from `main`.
+1. Git tag the merge commit and push
+```
+git tag vX.X.X
+git push origin vX.X.X
+```
+1. Visit the [release pipeline](https://buildkite.com/buildkite/test-collector-ruby-release) to unblock it and confirm the new version is pushed to rubygems.org
 1. Create a [new release in github](https://github.com/buildkite/test-collector-ruby/releases).
 
 ## 📜 MIT License


### PR DESCRIPTION
This adds a new pipeline.yml specifically for pushing gem releases to rubygems.org. We use the `rubygems-oidc` plugin to swap a Buildkite OIDC token for a temporary rubygems.org token that has permission to push this gem - that exchange process will only work from a special Buildkite pipeline that is triggered by a tag push to the repository.

I've updated the README with the new process. It's largely the same, except now any staff member with access to the release pipeline can approve the release. They no longer need to be added as an owner on [the gem](https://rubygems.org/gems/buildkite-test_collector), or need to have access to any shared credentials for our rubygems.org user.