### PR TITLE
Release v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v2.8.0
+
+* Buildkite::TestCollector.tags: specify tags for all executions by @pda in https://github.com/buildkite/test-collector-ruby/pull/235
+* Add Ruby 3.4 to Buildkite build matrix by @gchan in https://github.com/buildkite/test-collector-ruby/pull/236
+
+**Full Changelog**: https://github.com/buildkite/test-collector-ruby/compare/v2.7.2...v2.8.0
+
 ## v2.7.2
 
 - Fixes RSpec library hook bug introduced in v2.7.1 #230 - @malclocke

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    buildkite-test_collector (2.7.2)
+    buildkite-test_collector (2.8.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/buildkite/test_collector/version.rb
+++ b/lib/buildkite/test_collector/version.rb
@@ -2,7 +2,7 @@
 
 module Buildkite
   module TestCollector
-    VERSION = "2.7.2"
+    VERSION = "2.8.0"
     NAME = "buildkite-test_collector"
   end
 end


### PR DESCRIPTION
Prepare for v2.8.0 release.

> * Buildkite::TestCollector.tags: specify tags for all executions by @pda in https://github.com/buildkite/test-collector-ruby/pull/235
> * Add Ruby 3.4 to Buildkite build matrix by @gchan in https://github.com/buildkite/test-collector-ruby/pull/236
> 
> **Full Changelog**: https://github.com/buildkite/test-collector-ruby/compare/v2.7.2...v2.8.0


Related:
- https://github.com/buildkite/test-collector-ruby/pull/237