### PR TITLE
API endpoint configurable with `BUILDKITE_ANALYTICS_ENDPOINT`

### DIFF
--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -44,7 +44,7 @@ module Buildkite
 
     def self.configure(hook:, token: nil, url: nil, tracing_enabled: true, artifact_path: nil, env: {}, tags: {})
       self.api_token = (token || ENV["BUILDKITE_ANALYTICS_TOKEN"])&.strip
-      self.url = url || DEFAULT_URL
+      self.url = url || ENV["BUILDKITE_ANALYTICS_ENDPOINT"] || DEFAULT_URL
       self.tracing_enabled = tracing_enabled
       self.artifact_path = artifact_path
       self.env = env


### PR DESCRIPTION
Make the API endpoint configurable from the `BUILDKITE_ANALYTICS_ENDPOINT` environment variable.

It defaults to `https://analytics-api.buildkite.com/v1/uploads`, was previously only configurable by Ruby code:

```ruby
Buildkite::TestCollector.configure(url: "http://localhost:1234/example", …)
```

But it can be useful to inject different endpoints without changing the code, for testing etc.