### PR TITLE
`Buildkite::TestCollector.tag_execution(key, value)`

### DIFF
--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -77,6 +77,18 @@ module Buildkite
       tracer&.leave
     end
 
+    # Set a key=value tag on the current test execution.
+    def self.tag_execution(key, value)
+      tags = Thread.current[:_buildkite_tags]
+      raise "_buildkite_tags not available" unless tags
+
+      unless key.is_a?(String) && value.is_a?(String)
+        raise ArgumentError, "tag key and value expected string"
+      end
+
+      tags[key] = value
+    end
+
     def self.enable_tracing!
       return unless self.tracing_enabled
 

--- a/lib/buildkite/test_collector/minitest_plugin/trace.rb
+++ b/lib/buildkite/test_collector/minitest_plugin/trace.rb
@@ -5,6 +5,7 @@ module Buildkite::TestCollector::MinitestPlugin
     attr_accessor :example
     attr_writer :failure_reason, :failure_expanded
     attr_reader :history
+    attr_reader :tags
 
     RESULT_CODES = {
       '.' => 'passed',
@@ -15,9 +16,10 @@ module Buildkite::TestCollector::MinitestPlugin
 
     FILE_PATH_REGEX = /^(.*?\.(rb|feature))/
 
-    def initialize(example, history:)
+    def initialize(example, history:, tags: nil)
       @example = example
       @history = history
+      @tags = tags
     end
 
     def result
@@ -38,6 +40,7 @@ module Buildkite::TestCollector::MinitestPlugin
         failure_reason: failure_reason,
         failure_expanded: failure_expanded,
         history: history,
+        tags: tags,
       ).select { |_, value| !value.nil? }
     end
 

--- a/lib/buildkite/test_collector/rspec_plugin/trace.rb
+++ b/lib/buildkite/test_collector/rspec_plugin/trace.rb
@@ -4,14 +4,16 @@ module Buildkite::TestCollector::RSpecPlugin
   class Trace
     attr_accessor :example, :failure_reason, :failure_expanded
     attr_reader :history
+    attr_reader :tags
 
     FILE_PATH_REGEX = /^(.*?\.(rb|feature))/
 
-    def initialize(example, history:, failure_reason: nil, failure_expanded: [])
+    def initialize(example, history:, failure_reason: nil, failure_expanded: [], tags: nil)
       @example = example
       @history = history
       @failure_reason = failure_reason
       @failure_expanded = failure_expanded
+      @tags = tags
     end
 
     def result
@@ -32,6 +34,7 @@ module Buildkite::TestCollector::RSpecPlugin
         failure_reason: failure_reason,
         failure_expanded: failure_expanded,
         history: history,
+        tags: tags,
       ).select { |_, value| !value.nil? }
     end
 

--- a/spec/test_collector/minitest_plugin/trace_spec.rb
+++ b/spec/test_collector/minitest_plugin/trace_spec.rb
@@ -5,8 +5,24 @@ require "minitest"
 require "pathname"
 
 RSpec.describe Buildkite::TestCollector::MinitestPlugin::Trace do
-  subject(:trace) { Buildkite::TestCollector::MinitestPlugin::Trace.new(example, history: history) }
-  let(:example) { double("Minitest::Test", name: "test_it_passes", test_it_passes: nil, result_code: 'F', failure: failure, failures: [failure, another_failure]) }
+  subject(:trace) do
+    Buildkite::TestCollector::MinitestPlugin::Trace.new(
+      example,
+      history: history,
+      tags: tags,
+    )
+  end
+
+  let(:example) do
+    double(
+      "Minitest::Test",
+      name: "test_it_passes",
+      test_it_passes: nil,
+      result_code: 'F',
+      failure: failure,
+      failures: [failure, another_failure],
+    )
+  end
 
   # failure is either Minitest::Assertion or Minitest::UnexpectedError object. 
   # ref: https://github.com/minitest/minitest/blob/0984e29995a5c0f4dcf3c185442bcb4f493ed5e3/lib/minitest/test.rb#L198
@@ -29,6 +45,8 @@ RSpec.describe Buildkite::TestCollector::MinitestPlugin::Trace do
       ]
     }
   end
+
+  let(:tags) { nil }
 
   describe '#as_hash' do
     it 'removes invalid UTF-8 characters from top level values' do
@@ -94,5 +112,12 @@ RSpec.describe Buildkite::TestCollector::MinitestPlugin::Trace do
       end
     end
 
+    context "with tags" do
+      let(:tags) { { "hello" => "world" } }
+
+      it "includes the tags" do
+        expect(trace.as_hash[:tags]).to eq({ "hello" => "world" })
+      end
+    end
   end
 end

--- a/spec/test_collector/rspec_plugin/trace_spec.rb
+++ b/spec/test_collector/rspec_plugin/trace_spec.rb
@@ -3,8 +3,16 @@
 require "buildkite/test_collector/rspec_plugin/trace"
 
 RSpec.describe Buildkite::TestCollector::RSpecPlugin::Trace do
-  subject(:trace) { Buildkite::TestCollector::RSpecPlugin::Trace.new(example, history: history) }
+  subject(:trace) do
+    Buildkite::TestCollector::RSpecPlugin::Trace.new(
+      example,
+      history: history,
+      tags: tags,
+    )
+  end
+
   let(:example) { double(id: "test for invalid character '\xC8'").as_null_object }
+
   let(:history) do
     {
       children: [
@@ -15,6 +23,8 @@ RSpec.describe Buildkite::TestCollector::RSpecPlugin::Trace do
       ]
     }
   end
+
+  let(:tags) { nil }
 
   describe '#as_hash' do
     it 'removes invalid UTF-8 characters from nested values' do
@@ -28,6 +38,14 @@ RSpec.describe Buildkite::TestCollector::RSpecPlugin::Trace do
       history_json = trace.as_hash[:history].to_json
 
       expect(history_json).to include('347611.734956')
+    end
+
+    context "with tags" do
+      let(:tags) { { "hello" => "world" } }
+
+      it "includes the tags" do
+        expect(trace.as_hash[:tags]).to eq({ "hello" => "world" })
+      end
     end
   end
 end


### PR DESCRIPTION
Draft support for per-execution tagging.

- [x] Decide if `Buildkite::TestCollector.tag_execution(key, value)` is an okay API for this.
- [x] Add some test coverage.

I don't love adding yet another `Thread.current[:_buildkite…]` fiber-local (global-ish) name, but I don't see a really good place to put these tags otherwise, and really it's an inconsequential implementation detail, compared to the public API in front of it. I don't think they really belong in `Buildkite::TestCollector::Tracer` (we're tagging the execution, not the potentially-nested traces therein) and adding them there just adds complexity.