### PR TITLE
Release v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.9.0
+
+* `Buildkite::TestCollector.tag_execution(key, value)` by @pda in https://github.com/buildkite/test-collector-ruby/pull/240
+
+**Full Changelog**: https://github.com/buildkite/test-collector-ruby/compare/v2.8.0...v2.9.0
+
 ## v2.8.0
 
 * Buildkite::TestCollector.tags: specify tags for all executions by @pda in https://github.com/buildkite/test-collector-ruby/pull/235

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    buildkite-test_collector (2.8.0)
+    buildkite-test_collector (2.9.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/buildkite/test_collector/version.rb
+++ b/lib/buildkite/test_collector/version.rb
@@ -2,7 +2,7 @@
 
 module Buildkite
   module TestCollector
-    VERSION = "2.8.0"
+    VERSION = "2.9.0"
     NAME = "buildkite-test_collector"
   end
 end


### PR DESCRIPTION
Prepare for v2.9.0 release with per-execution tagging.

> ## v2.9.0
> 
> * `Buildkite::TestCollector.tag_execution(key, value)` by @pda in #240
> 
> **Full Changelog**: https://github.com/buildkite/test-collector-ruby/compare/v2.8.0...v2.9.0