### PR TITLE
Send Ruby location_prefix in run_env

### DIFF
--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -40,6 +40,7 @@ class Buildkite::TestCollector::CI
       "language_version" => RUBY_VERSION,
       "version" => Buildkite::TestCollector::VERSION,
       "collector" => "ruby-#{Buildkite::TestCollector::NAME}",
+      "location_prefix" => Buildkite::TestCollector.location_prefix,
       "trace_min_duration" => Buildkite::TestCollector.trace_min_duration&.to_s,
     }.select { |_, value| !value.nil? }
   end

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Buildkite::TestCollector::CI do
       fake_env("BUILDKITE_BUILD_ID", nil)
       fake_env("GITHUB_RUN_NUMBER", nil)
       fake_env("CIRCLE_BUILD_NUM", nil)
+      fake_env("BUILDKITE_ANALYTICS_LOCATION_PREFIX", nil)
 
       Buildkite::TestCollector.configure(hook: :rspec, env: { "test" => test_value })
     end
@@ -31,6 +32,41 @@ RSpec.describe Buildkite::TestCollector::CI do
       result = Buildkite::TestCollector::CI.env
 
       expect(result["test"]).to eq test_value
+    end
+
+    it "omits location_prefix when it is not configured" do
+      result = Buildkite::TestCollector::CI.env
+
+      expect(result).not_to include("location_prefix")
+    end
+
+    context "with configured location_prefix" do
+      before do
+        Buildkite::TestCollector.configure(
+          hook: :rspec,
+          env: { "test" => test_value },
+          location_prefix: "some-sub-dir"
+        )
+      end
+
+      it "includes location_prefix in run_env" do
+        expect(Buildkite::TestCollector::CI.env).to include(
+          "location_prefix" => "some-sub-dir",
+        )
+      end
+    end
+
+    context "with BUILDKITE_ANALYTICS_LOCATION_PREFIX" do
+      before do
+        fake_env("BUILDKITE_ANALYTICS_LOCATION_PREFIX", "some-sub-dir")
+        Buildkite::TestCollector.configure(hook: :rspec, env: { "test" => test_value })
+      end
+
+      it "includes location_prefix in run_env" do
+        expect(Buildkite::TestCollector::CI.env).to include(
+          "location_prefix" => "some-sub-dir",
+        )
+      end
     end
 
     context "when running on Buildkite" do

--- a/spec/test_collector/uploader_spec.rb
+++ b/spec/test_collector/uploader_spec.rb
@@ -22,6 +22,22 @@ RSpec.describe Buildkite::TestCollector::Uploader do
       future.wait if future
     end
 
+    it 'includes location_prefix in run_env' do
+      allow(Buildkite::TestCollector).to receive(:location_prefix).and_return('some-sub-dir')
+
+      expect(http_client_double).to receive(:post_upload).with(
+        data: [{some: 'data'}],
+        run_env: hash_including(
+          "collector" => "ruby-buildkite-test_collector",
+          "location_prefix" => "some-sub-dir",
+        ),
+        tags: {},
+      )
+
+      future = Buildkite::TestCollector::Uploader.upload([{some: 'data'}])
+      future.wait if future
+    end
+
     context 'when there is RuntimeError' do
       before do
         allow(http_client_double).to receive(:post_upload).and_raise(RuntimeError)


### PR DESCRIPTION
## Summary
- add configured location_prefix to CI analytics run_env
- cover configured, env-provided, and unset location_prefix behaviour
- assert uploader passes location_prefix through in run_env

## Verification
- BUNDLE_PATH=vendor/bundle bundle exec rspec spec/test_collector/ci_spec.rb spec/test_collector/uploader_spec.rb spec/test_collector/http_client_spec.rb
- BUNDLE_PATH=vendor/bundle bundle exec rspec