### PR TITLE
Send `test_runner` in `run_env`

### DIFF
--- a/lib/buildkite/test_collector.rb
+++ b/lib/buildkite/test_collector.rb
@@ -37,6 +37,7 @@ module Buildkite
       attr_accessor :tracing_enabled
       attr_accessor :artifact_path
       attr_accessor :location_prefix
+      attr_accessor :test_runner
       attr_accessor :env
       attr_accessor :tags
       attr_accessor :batch_size
@@ -54,6 +55,7 @@ module Buildkite
       self.tracing_enabled = tracing_enabled
       self.artifact_path = artifact_path
       self.location_prefix = location_prefix || ENV["BUILDKITE_ANALYTICS_LOCATION_PREFIX"]
+      self.test_runner = hook.to_s
       self.env = env
       self.tags = tags
       self.batch_size = ENV.fetch("BUILDKITE_ANALYTICS_UPLOAD_BATCH_SIZE") { DEFAULT_UPLOAD_BATCH_SIZE }.to_i

--- a/lib/buildkite/test_collector/ci.rb
+++ b/lib/buildkite/test_collector/ci.rb
@@ -41,6 +41,7 @@ class Buildkite::TestCollector::CI
       "version" => Buildkite::TestCollector::VERSION,
       "collector" => "ruby-#{Buildkite::TestCollector::NAME}",
       "location_prefix" => Buildkite::TestCollector.location_prefix,
+      "test_runner" => Buildkite::TestCollector.test_runner,
       "trace_min_duration" => Buildkite::TestCollector.trace_min_duration&.to_s,
     }.select { |_, value| !value.nil? }
   end

--- a/spec/test_collector/ci_spec.rb
+++ b/spec/test_collector/ci_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe Buildkite::TestCollector::CI do
       expect(result).not_to include("location_prefix")
     end
 
+    it "includes the configured test_runner in run_env" do
+      result = Buildkite::TestCollector::CI.env
+
+      expect(result).to include("test_runner" => "rspec")
+    end
+
     context "with configured location_prefix" do
       before do
         Buildkite::TestCollector.configure(
@@ -105,6 +111,7 @@ RSpec.describe Buildkite::TestCollector::CI do
           "version" => version,
           "collector" => name,
           "test" => test_value,
+          "test_runner" => "rspec",
         })
       end
 
@@ -139,6 +146,7 @@ RSpec.describe Buildkite::TestCollector::CI do
             "version" => version,
             "collector" => name,
             "test" => test_value,
+            "test_runner" => "rspec",
           })
         end
       end
@@ -178,6 +186,7 @@ RSpec.describe Buildkite::TestCollector::CI do
           "version" => version,
           "collector" => name,
           "test" => test_value,
+          "test_runner" => "rspec",
         })
       end
 
@@ -208,6 +217,7 @@ RSpec.describe Buildkite::TestCollector::CI do
             "version" => version,
             "collector" => name,
             "test" => test_value,
+            "test_runner" => "rspec",
           })
         end
       end
@@ -243,6 +253,7 @@ RSpec.describe Buildkite::TestCollector::CI do
           "version" => version,
           "collector" => name,
           "test" => test_value,
+          "test_runner" => "rspec",
         })
       end
 
@@ -273,6 +284,7 @@ RSpec.describe Buildkite::TestCollector::CI do
             "version" => version,
             "collector" => name,
             "test" => test_value,
+            "test_runner" => "rspec",
           })
         end
       end
@@ -309,6 +321,7 @@ RSpec.describe Buildkite::TestCollector::CI do
           "version" => version,
           "collector" => name,
           "test" => test_value,
+          "test_runner" => "rspec",
         })
       end
 
@@ -340,6 +353,7 @@ RSpec.describe Buildkite::TestCollector::CI do
             "version" => version,
             "collector" => name,
             "test" => test_value,
+            "test_runner" => "rspec",
           })
         end
       end
@@ -362,6 +376,7 @@ RSpec.describe Buildkite::TestCollector::CI do
           "version" => version,
           "collector" => name,
           "test" => test_value,
+          "test_runner" => "rspec",
         })
       end
 
@@ -392,6 +407,7 @@ RSpec.describe Buildkite::TestCollector::CI do
             "version" => version,
             "collector" => name,
             "test" => test_value,
+            "test_runner" => "rspec",
           })
         end
       end
@@ -412,6 +428,7 @@ RSpec.describe Buildkite::TestCollector::CI do
           "version" => version,
           "collector" => name,
           "test" => test_value,
+          "test_runner" => "rspec",
         })
       end
 
@@ -442,6 +459,7 @@ RSpec.describe Buildkite::TestCollector::CI do
             "version" => version,
             "collector" => name,
             "test" => test_value,
+            "test_runner" => "rspec",
           })
         end
       end


### PR DESCRIPTION
Right now the Ruby collector doesn't tell Test Engine which test framework produced an upload. That means Test Engine can't reliably distinguish rspec, minitest, and cucumber uploads from each other. We're implementing the same thing for bktec, so this brings the Ruby collector in line.

This PR adds `test_runner` to `run_env`, set from the hook the collector was configured with (`rspec`, `minitest`, or `cucumber`).