### PR TITLE
Bump version to 2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v2.14.0
+
+* Send `location_prefix` in `run_env`
+* Send `test_runner` in `run_env`
+
+**Full Changelog**: https://github.com/buildkite/test-collector-ruby/compare/v2.13.0...v2.14.0
+
 ## v2.13.0
 
 * Remove `./` prefix from minitest collector file paths

--- a/lib/buildkite/test_collector/version.rb
+++ b/lib/buildkite/test_collector/version.rb
@@ -2,7 +2,7 @@
 
 module Buildkite
   module TestCollector
-    VERSION = "2.13.0"
+    VERSION = "2.14.0"
     NAME = "buildkite-test_collector"
   end
 end


### PR DESCRIPTION
## Summary

- bump the gem version to `2.14.0`
- add the `v2.14.0` changelog entry for `location_prefix` and `test_runner` in `run_env`

