### PR TITLE
Fix file_name truncation in RSpec/Cucumber FILE_PATH_REGEX

### DIFF
--- a/lib/buildkite/test_collector/cucumber_plugin/trace.rb
+++ b/lib/buildkite/test_collector/cucumber_plugin/trace.rb
@@ -5,7 +5,9 @@ module Buildkite::TestCollector::CucumberPlugin
     attr_accessor :scenario, :failure_reason, :failure_expanded
     attr_reader :history, :tags, :location_prefix
 
-    FILE_PATH_REGEX = /^(.*?\.(rb|feature))/
+    # scenario.location looks like "./features/foo.feature:12" - strip the
+    # trailing line number to get the file path.
+    LOCATION_LINE_SUFFIX_REGEX = /:\d+\z/
 
     def initialize(scenario, history:, failure_reason: nil, failure_expanded: [], tags: nil, location_prefix: nil)
       @scenario         = scenario
@@ -49,7 +51,7 @@ module Buildkite::TestCollector::CucumberPlugin
     end
 
     def file_name
-      @file_name ||= location&.to_s[FILE_PATH_REGEX]
+      @file_name ||= location&.to_s&.sub(LOCATION_LINE_SUFFIX_REGEX, "")
     end
   end
 end

--- a/lib/buildkite/test_collector/rspec_plugin/trace.rb
+++ b/lib/buildkite/test_collector/rspec_plugin/trace.rb
@@ -7,7 +7,18 @@ module Buildkite::TestCollector::RSpecPlugin
     attr_reader :tags
     attr_reader :location_prefix
 
-    FILE_PATH_REGEX = /^(.*?\.(rb|feature))/
+    # example.id looks like "./spec/foo_spec.rb[1:2]" - strip the trailing
+    # example index suffix to get the file path.
+    ID_INDEX_SUFFIX_REGEX = /\[[\d:]+\]\z/
+
+    # example.location looks like "./spec/foo_spec.rb:42" - strip the
+    # trailing line number to get the file path.
+    LOCATION_LINE_SUFFIX_REGEX = /:\d+\z/
+
+    # shared_example_call_location is a raw backtrace line, e.g.
+    # "./spec/foo_spec.rb:12:in `block (2 levels) in <top (required)>'" -
+    # strip the trailing line number and frame label to get the file path.
+    BACKTRACE_LINE_SUFFIX_REGEX = /:\d+:in\b.*\z/
 
     def initialize(example, history:, failure_reason: nil, failure_expanded: [], tags: nil, location_prefix: nil)
       @example = example
@@ -42,8 +53,8 @@ module Buildkite::TestCollector::RSpecPlugin
 
     def file_name
       @file_name ||= begin
-        identifier_file_name = strip_invalid_utf8_chars(example.id)[FILE_PATH_REGEX]
-        location_file_name = example.location[FILE_PATH_REGEX]
+        identifier_file_name = strip_invalid_utf8_chars(example.id).sub(ID_INDEX_SUFFIX_REGEX, "")
+        location_file_name = example.location.sub(LOCATION_LINE_SUFFIX_REGEX, "")
 
         if identifier_file_name != location_file_name
           # If the identifier and location files are not the same, we assume
@@ -52,7 +63,7 @@ module Buildkite::TestCollector::RSpecPlugin
           if shared_example?
             # Taking the last frame in this backtrace will give us the original
             # entry point for the shared example
-            shared_example_call_location[FILE_PATH_REGEX]
+            shared_example_call_location.sub(BACKTRACE_LINE_SUFFIX_REGEX, "")
           else
             "Unknown"
           end

--- a/spec/support/fixtures/features/a.feature.d/login.feature
+++ b/spec/support/fixtures/features/a.feature.d/login.feature
@@ -1,0 +1,5 @@
+Feature: Login
+  Scenario: Simple login
+    Given I have a valid account
+    When I log in
+    Then I should be logged in

--- a/spec/test_collector/cucumber_plugin/trace_spec.rb
+++ b/spec/test_collector/cucumber_plugin/trace_spec.rb
@@ -75,6 +75,42 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7')
           )
         end
       end
+
+      context "when the location includes a line number" do
+        let(:example) do
+          double(
+            Cucumber::RunningTestCase::TestCase,
+            name: "test_it_passes",
+            location: "spec/support/fixtures/features/a.feature:12",
+            "passed?": false,
+            "failed?": true,
+          )
+        end
+
+        it "strips the line number from the file_name" do
+          expect(trace.as_hash).to include(
+            file_name: "spec/support/fixtures/features/a.feature",
+          )
+        end
+      end
+
+      context "when the path contains a .feature-like segment before the real extension" do
+        let(:example) do
+          double(
+            Cucumber::RunningTestCase::TestCase,
+            name: "test_it_passes",
+            location: "spec/support/fixtures/features/a.feature.d/login.feature:12",
+            "passed?": false,
+            "failed?": true,
+          )
+        end
+
+        it "does not truncate the file_name at the first .feature occurrence" do
+          expect(trace.as_hash).to include(
+            file_name: "spec/support/fixtures/features/a.feature.d/login.feature",
+          )
+        end
+      end
     end
   end
 else

--- a/spec/test_collector/http_client_spec.rb
+++ b/spec/test_collector/http_client_spec.rb
@@ -16,8 +16,9 @@ RSpec.describe Buildkite::TestCollector::HTTPClient do
     OpenStruct.new(
       example_group: example_group,
       description: "mince and cheese",
-      id: "12",
-      location: "123 Pie St",
+      id: "./spec/pie_spec.rb[1:2]",
+      location: "./spec/pie_spec.rb:5",
+      metadata: { shared_group_inclusion_backtrace: [] },
       execution_result: execution_result
     )
   end
@@ -41,7 +42,8 @@ RSpec.describe Buildkite::TestCollector::HTTPClient do
         {
           "scope": "i love to eat pies",
           "name": "mince and cheese",
-          "location": "123 Pie St",
+          "location": "./spec/pie_spec.rb:5",
+          "file_name": "./spec/pie_spec.rb",
           "result": "passed",
           "failure_expanded": [],
           "history": "pie lore"

--- a/spec/test_collector/rspec_plugin/trace_spec.rb
+++ b/spec/test_collector/rspec_plugin/trace_spec.rb
@@ -50,6 +50,40 @@ RSpec.describe Buildkite::TestCollector::RSpecPlugin::Trace do
           )
         end
       end
+
+      context "when the path contains a .rb-like segment before the real extension" do
+        let(:file_path) { "spec/archive.rb.d/widget_spec.rb" }
+
+        it "does not truncate the file_name at the first .rb occurrence" do
+          expect(trace.as_hash).to include(
+            file_name: "spec/archive.rb.d/widget_spec.rb",
+            location: "spec/archive.rb.d/widget_spec.rb:42",
+          )
+        end
+      end
+
+      context "when the example is a shared example" do
+        let(:example) do
+          fake_example(
+            file_path: "./spec/foo_spec.rb",
+            id: "./spec/shared_examples/a_widget.rb[1:1]",
+            location: "./spec/foo_spec.rb:12",
+            metadata: {
+              shared_group_inclusion_backtrace: [
+                double(
+                  inclusion_location: "./spec/foo_spec.rb:12:in `block (2 levels) in <top (required)>'"
+                )
+              ]
+            },
+          )
+        end
+
+        it "returns the actual spec file, not the shared-examples library file" do
+          expect(trace.as_hash).to include(
+            file_name: "./spec/foo_spec.rb",
+          )
+        end
+      end
     end
 
     it 'removes invalid UTF-8 characters from nested values' do


### PR DESCRIPTION
We want to tag `test.selector.primary` for test results uploaded by test collectors. We can't do that currently for the Ruby collectors (rspec, cucumber) because `file_name` extraction has an edge case where it can silently truncate valid paths.

The problem is `FILE_PATH_REGEX` (`/^(.*?\.(rb|feature))/`), a non-greedy match up to the *first* `.rb`/`.feature` occurrence in the string. Nothing stops a path from having one of those extensions earlier than the real file extension, e.g. `spec/archive.rb.d/widget_spec.rb`, and if that happens, it truncates to `spec/archive.rb`. It's an unusual naming pattern and unlikely to show up in practice, but `ta-ingestion` can't rely on `file_name` while it's even possible, so it's blocking `test.selector.primary` inference for this collector.

`FILE_PATH_REGEX` was reused against three differently-shaped strings, so instead of patching the regex, I replaced it with a targeted suffix-strip for each shape. This is a more robust extraction strategy in general, not just a fix for the one example above:

- `example.id`, e.g. `./spec/foo_spec.rb[1:2]` → strip the trailing `[...]` index suffix
- `example.location`, e.g. `./spec/foo_spec.rb:42` → strip the trailing `:<lineno>`
- `shared_example_call_location` (a backtrace line), e.g. `` ./spec/foo_spec.rb:12:in `block (2 levels) in <top (required)>' `` → strip the trailing `:<lineno>:in ...` frame label

The existing mismatch-detection/fallback branch for shared examples (`it_behaves_like`) is untouched, it still compares the id and location paths and falls back to `shared_example_call_location` when they diverge.

Applied the same fix to the Cucumber plugin, which had its own copy of the same regex.

Also, while working on this, I found `http_client_spec.rb` had a fake example with unrealistic `id`/`location` values that happened to both fail to match the old regex (so they were coincidentally equal), which masked a `NoMethodError` from missing `metadata` once the extraction got fixed. Updated it with realistic values.

## Test plan

- [x] Regression test covering a nested path like `spec/archive.rb.d/widget_spec.rb`
- [x] Regression test covering a shared example (`it_behaves_like`) proving the actual spec file is returned, not the shared-examples library file
- [x] Same fix applied to Cucumber plugin, with equivalent regression tests
- [x] Full test suite passes (`bundle exec rspec`, 71 examples, 0 failures)