### PR TITLE
Generate an external_id for each RSpec execution

### DIFF
--- a/lib/buildkite/test_collector/library_hooks/rspec.rb
+++ b/lib/buildkite/test_collector/library_hooks/rspec.rb
@@ -37,7 +37,8 @@ RSpec.configure do |config|
         example,
         history: tracer.history,
         tags: tags,
-        location_prefix: Buildkite::TestCollector.location_prefix
+        location_prefix: Buildkite::TestCollector.location_prefix,
+        external_id: Buildkite::TestCollector::UUID.v7,
       )
 
       Buildkite::TestCollector.uploader.traces[example.id] = trace

--- a/lib/buildkite/test_collector/rspec_plugin/trace.rb
+++ b/lib/buildkite/test_collector/rspec_plugin/trace.rb
@@ -9,13 +9,14 @@ module Buildkite::TestCollector::RSpecPlugin
 
     FILE_PATH_REGEX = /^(.*?\.(rb|feature))/
 
-    def initialize(example, history:, failure_reason: nil, failure_expanded: [], tags: nil, location_prefix: nil)
+    def initialize(example, history:, failure_reason: nil, failure_expanded: [], tags: nil, location_prefix: nil, external_id: nil)
       @example = example
       @history = history
       @failure_reason = failure_reason
       @failure_expanded = failure_expanded
       @tags = tags
       @location_prefix = location_prefix
+      @external_id = external_id
     end
 
     def result

--- a/lib/buildkite/test_collector/trace.rb
+++ b/lib/buildkite/test_collector/trace.rb
@@ -3,8 +3,11 @@
 module Buildkite
   module TestCollector
     class Trace
+      attr_accessor :external_id
+
       def as_hash
         strip_invalid_utf8_chars(
+          external_id: external_id,
           scope: scope,
           name: name,
           location: prepend_location_prefix(location),

--- a/lib/buildkite/test_collector/uuid.rb
+++ b/lib/buildkite/test_collector/uuid.rb
@@ -4,9 +4,19 @@ require "securerandom"
 
 class Buildkite::TestCollector::UUID
   GET_UUID = SecureRandom.method(:uuid)
-  private_constant :GET_UUID
+  # `uuid_v7` is only available on Ruby 3.3+; fall back to UUIDv4 on older Rubies.
+  # Once we require Ruby 3.3+ (planned alongside the OTel work), drop this
+  # fallback and just call SecureRandom.uuid_v7 directly.
+  GET_UUID_V7 = SecureRandom.respond_to?(:uuid_v7) ? SecureRandom.method(:uuid_v7) : GET_UUID
+  private_constant :GET_UUID, :GET_UUID_V7
 
   def self.call
     GET_UUID.call
+  end
+
+  # Time-sortable UUID used for execution external IDs, giving storage
+  # locality when persisted (e.g. as a ClickHouse primary key component).
+  def self.v7
+    GET_UUID_V7.call
   end
 end

--- a/spec/test_collector/rspec_plugin/trace_spec.rb
+++ b/spec/test_collector/rspec_plugin/trace_spec.rb
@@ -9,11 +9,13 @@ RSpec.describe Buildkite::TestCollector::RSpecPlugin::Trace do
       history: history,
       tags: tags,
       location_prefix: location_prefix,
+      external_id: external_id,
     )
   end
 
   let(:example) { double(id: "test for invalid character '\xC8'").as_null_object }
   let(:location_prefix) { nil }
+  let(:external_id) { nil }
 
   let(:history) do
     {
@@ -70,6 +72,14 @@ RSpec.describe Buildkite::TestCollector::RSpecPlugin::Trace do
 
       it "includes the tags" do
         expect(trace.as_hash[:tags]).to eq({ "hello" => "world" })
+      end
+    end
+
+    context "with an external ID" do
+      let(:external_id) { "019c8d97-f9ad-75a5-8173-dc6c1b54b901" }
+
+      it "includes the external ID" do
+        expect(trace.as_hash[:external_id]).to eq(external_id)
       end
     end
   end

--- a/spec/test_collector/uuid_spec.rb
+++ b/spec/test_collector/uuid_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe Buildkite::TestCollector::UUID do
+  describe '.call' do
+    it 'returns a UUID' do
+      expect(described_class.call).to match(/\A[0-9a-f-]{36}\z/)
+    end
+  end
+
+  describe '.v7' do
+    it 'returns a UUID' do
+      expect(described_class.v7).to match(/\A[0-9a-f-]{36}\z/)
+    end
+
+    it 'returns a different value on each call' do
+      expect(described_class.v7).not_to eq(described_class.v7)
+    end
+  end
+end


### PR DESCRIPTION
We want to start ingesting OTel spans, eventually replacing our in-house span tracing. To join an execution with its OTel spans, each execution needs an opaque, time-sortable ID we can send to the Upload API.

I generated a UUIDv7 per RSpec execution and included it in the upload payload as `external_id`. UUIDv7 gives time ordering and storage locality once it's persisted (matches the approach from the OTel PoC, #261).

RSpec only for now. We're only dogfooding OTel from the RSpec hook, so Minitest and Cucumber don't need this yet.

`uuid_v7` needs Ruby 3.3+, but this gem still supports Ruby 2.3+, so `Buildkite::TestCollector::UUID.v7` falls back to UUIDv4 on older Rubies. Once we bump the required Ruby version for the OTel work, we can drop the fallback and call `SecureRandom.uuid_v7` directly.